### PR TITLE
47 fix incorrect object parsing

### DIFF
--- a/generated/actions.json
+++ b/generated/actions.json
@@ -520,6 +520,7 @@
         "name": "Influence Checks",
         "type": "table",
         "value": {
+          "title": "Influence Checks",
           "headers": [
             "Ability Check",
             "Interaction"
@@ -656,7 +657,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "*Here are a few examples of the sorts of thing you can do in tandem with your movement and action:\n\n• draw or sheathe a sword\n• open or close a door\n• withdraw a potion from your backpack\n• pick up a dropped axe\n• take a bauble from a table\n• remove a ring from your finger\n• stuff some food into your mouth\n• plant a banner in the ground\n• fish a few coins from your belt pouch\n• drink all the ale in a flagon\n• throw a lever or a switch\n• pull a torch from a sconce\n• take a book from a shelf you can reach\n• extinguish a small flame\n• don a mask\n• pull the hood of your cloak up and over your head\n• put your ear to a door\n• kick a small stone\n• turn a key in a lock\n• tap the floor with a 10-foot pole\n• hand an item to another character*"
+        "value": "*Here are a few examples of the sorts of thing you can do in tandem with your movement and action:*\n*• draw or sheathe a sword\n• open or close a door\n• withdraw a potion from your backpack\n• pick up a dropped axe\n• take a bauble from a table\n• remove a ring from your finger\n• stuff some food into your mouth\n• plant a banner in the ground\n• fish a few coins from your belt pouch\n• drink all the ale in a flagon\n• throw a lever or a switch\n• pull a torch from a sconce\n• take a book from a shelf you can reach\n• extinguish a small flame\n• don a mask\n• pull the hood of your cloak up and over your head\n• put your ear to a door\n• kick a small stone\n• turn a key in a lock\n• tap the floor with a 10-foot pole\n• hand an item to another character*"
       }
     ]
   },
@@ -762,6 +763,7 @@
         "name": "Search",
         "type": "table",
         "value": {
+          "title": "Search",
           "headers": [
             "Skill",
             "Thing to Detect"
@@ -857,6 +859,7 @@
         "name": "Areas of Knowledge",
         "type": "table",
         "value": {
+          "title": "Areas of Knowledge",
           "headers": [
             "Skill",
             "Areas"

--- a/generated/classes.json
+++ b/generated/classes.json
@@ -34,6 +34,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68,6 +69,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -102,6 +104,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -136,6 +139,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -170,6 +174,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -204,6 +209,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -238,6 +244,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -272,6 +279,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -306,6 +314,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -340,6 +349,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -374,6 +384,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -408,6 +419,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -442,6 +454,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -476,6 +489,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -510,6 +524,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -544,6 +559,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -578,6 +594,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -612,6 +629,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -646,6 +664,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -680,6 +699,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -765,7 +785,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*As an artificer, you use tools when you cast your spells. When describing your spellcasting, think about how you're using a tool to perform the spell effect. If you cast __cure wounds__ using alchemist's supplies, you could be quickly producing a salve. If you cast it using tinker's tools, you might have a miniature mechanical spider that binds wounds. When you cast __poison spray__, you could fling foul chemicals or use a wand that spits venom. The effect of the spell is the same as for a spellcaster of any other class, but your method of spellcasting is special.\n\nThe same principle applies when you prepare your spells. As an artificer, you don't study a spellbook or pray to prepare your spells. Instead, you work with your tools and create the specialized items you'll use to produce your effects. If you replace __cure wounds__ with __heat metal__, you might be altering the device you use to heal—perhaps modifying a tool so that it channels heat instead of healing energy.\n\nSuch details don't limit you in any way or provide you with any benefit beyond the spell's effects. You don't have to justify how you're using tools to cast a spell. But describing your spellcasting creatively is a fun way to distinguish yourself from other spellcasters.*"
+          "value": "*As an artificer, you use tools when you cast your spells. When describing your spellcasting, think about how you're using a tool to perform the spell effect. If you cast __cure wounds__ using alchemist's supplies, you could be quickly producing a salve. If you cast it using tinker's tools, you might have a miniature mechanical spider that binds wounds. When you cast __poison spray__, you could fling foul chemicals or use a wand that spits venom. The effect of the spell is the same as for a spellcaster of any other class, but your method of spellcasting is special.*\n*The same principle applies when you prepare your spells. As an artificer, you don't study a spellbook or pray to prepare your spells. Instead, you work with your tools and create the specialized items you'll use to produce your effects. If you replace __cure wounds__ with __heat metal__, you might be altering the device you use to heal—perhaps modifying a tool so that it channels heat instead of healing energy.*\n*Such details don't limit you in any way or provide you with any benefit beyond the spell's effects. You don't have to justify how you're using tools to cast a spell. But describing your spellcasting creatively is a fun way to distinguish yourself from other spellcasters.*"
         },
         {
           "name": "Cantrips (0-Level Spells)",
@@ -837,7 +857,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*Artificers have invented numerous magical infusions, extraordinary processes that rapidly create magic items. To many, artificers seem like wonderworkers, accomplishing in hours what others need weeks to complete.\n\nThe description of each of the following infusions details the type of item that can receive it, along with whether the resulting magic item requires attunement.\n\nSome infusions specify a minimum artificer level. You can't learn such an infusion until you are at least that level.\n\nUnless an infusion's description says otherwise, you can't learn an infusion more than once.*"
+          "value": "*Artificers have invented numerous magical infusions, extraordinary processes that rapidly create magic items. To many, artificers seem like wonderworkers, accomplishing in hours what others need weeks to complete.*\n*The description of each of the following infusions details the type of item that can receive it, along with whether the resulting magic item requires attunement.*\n*Some infusions specify a minimum artificer level. You can't learn such an infusion until you are at least that level.*\n*Unless an infusion's description says otherwise, you can't learn an infusion more than once.*"
         },
         {
           "name": "Infusing an Item",
@@ -1155,6 +1175,7 @@
             "name": "Alchemist Spells",
             "type": "table",
             "value": {
+              "title": "Alchemist Spells",
               "headers": [
                 "Artificer Level",
                 "Spell"
@@ -1207,6 +1228,7 @@
             "name": "Experimental Elixir",
             "type": "table",
             "value": {
+              "title": "Experimental Elixir",
               "headers": [
                 "d6",
                 "Effect"
@@ -1403,6 +1425,7 @@
             "name": "Armorer Spells",
             "type": "table",
             "value": {
+              "title": "Armorer Spells",
               "headers": [
                 "Artificer Level",
                 "Spell"
@@ -1540,6 +1563,7 @@
             "name": "Artillerist Spells",
             "type": "table",
             "value": {
+              "title": "Artillerist Spells",
               "headers": [
                 "Artificer Level",
                 "Spell"
@@ -1592,6 +1616,7 @@
             "name": "Eldritch Cannons",
             "type": "table",
             "value": {
+              "title": "Eldritch Cannons",
               "headers": [
                 "Cannon",
                 "Activation"
@@ -1706,6 +1731,7 @@
             "name": "Battle Smith Spells",
             "type": "table",
             "value": {
+              "title": "Battle Smith Spells",
               "headers": [
                 "Artificer Level",
                 "Spell"
@@ -2814,6 +2840,7 @@
             "name": "Origin of the Beast",
             "type": "table",
             "value": {
+              "title": "Origin of the Beast",
               "headers": [
                 "d4",
                 "Origin"
@@ -2977,6 +3004,7 @@
             "name": "Wild Magic",
             "type": "table",
             "value": {
+              "title": "Wild Magic",
               "headers": [
                 "d8",
                 "Magical Effect"
@@ -3100,7 +3128,7 @@
           {
             "name": "",
             "type": "text",
-            "value": "*Usually when one creature moves out of a hostile creature's reach, the hostile creature can use its reaction to make an opportunity attack. However, forced movement—such as being pushed by a Path of the Juggernaut barbarian's __Thunderous Blows__ feature—doesn't provoke opportunity attack.\n\nLikewise, a juggernaut barbarian's __Hurricane Strike__ feature allows an ally to make a melee weapon attack as a reaction only if the foe ends its forced movement within 5 feet of the ally. If a foe is pushed through other spaces within 5 feet of your allies, those allies can't make normal opportunity attack against the foe.*"
+            "value": "*Usually when one creature moves out of a hostile creature's reach, the hostile creature can use its reaction to make an opportunity attack. However, forced movement—such as being pushed by a Path of the Juggernaut barbarian's __Thunderous Blows__ feature—doesn't provoke opportunity attack.*\n*Likewise, a juggernaut barbarian's __Hurricane Strike__ feature allows an ally to make a melee weapon attack as a reaction only if the foe ends its forced movement within 5 feet of the ally. If a foe is pushed through other spaces within 5 feet of your allies, those allies can't make normal opportunity attack against the foe.*"
           }
         ],
         "6": [
@@ -4697,6 +4725,7 @@
             "name": "Origin of the Beast",
             "type": "table",
             "value": {
+              "title": "Origin of the Beast",
               "headers": [
                 "d4",
                 "Origin"
@@ -4860,6 +4889,7 @@
             "name": "Wild Magic",
             "type": "table",
             "value": {
+              "title": "Wild Magic",
               "headers": [
                 "d8",
                 "Magical Effect"
@@ -4983,7 +5013,7 @@
           {
             "name": "",
             "type": "text",
-            "value": "*Usually when one creature moves out of a hostile creature's reach, the hostile creature can use its reaction to make an opportunity attack. However, forced movement—such as being pushed by a Path of the Juggernaut barbarian's __Thunderous Blows__ feature—doesn't provoke opportunity attack.\n\nLikewise, a juggernaut barbarian's __Hurricane Strike__ feature allows an ally to make a melee weapon attack as a reaction only if the foe ends its forced movement within 5 feet of the ally. If a foe is pushed through other spaces within 5 feet of your allies, those allies can't make normal opportunity attack against the foe.*"
+            "value": "*Usually when one creature moves out of a hostile creature's reach, the hostile creature can use its reaction to make an opportunity attack. However, forced movement—such as being pushed by a Path of the Juggernaut barbarian's __Thunderous Blows__ feature—doesn't provoke opportunity attack.*\n*Likewise, a juggernaut barbarian's __Hurricane Strike__ feature allows an ally to make a melee weapon attack as a reaction only if the foe ends its forced movement within 5 feet of the ally. If a foe is pushed through other spaces within 5 feet of your allies, those allies can't make normal opportunity attack against the foe.*"
           }
         ],
         "6": [
@@ -5600,6 +5630,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -5642,6 +5673,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -5684,6 +5716,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -5726,6 +5759,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -5768,6 +5802,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -5810,6 +5845,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -5852,6 +5888,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -5894,6 +5931,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -5936,6 +5974,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -5978,6 +6017,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6020,6 +6060,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6062,6 +6103,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6104,6 +6146,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6146,6 +6189,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6188,6 +6232,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6230,6 +6275,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6272,6 +6318,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6314,6 +6361,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6356,6 +6404,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6398,6 +6447,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -6648,7 +6698,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*Does your Bard beat a drum while chanting the deeds of ancient heroes? Strum a lute while crooning romantic tunes? Perform arias of stirring power? Recite dramatic monologues from classic tragedies? Use the rhythm of a folk dance to coordinate the movement of allies in battle? Compose naughty limericks?\n\nWhen you play a Bard, consider the style of artistic performance you favor, the moods you might invoke, and the themes that inspire your own creations. Are your poems inspired by moments of natural beauty, or are they brooding reflections on loss? Do you prefer lofty hymns or rowdy tavern songs? Are you drawn to laments for the fallen or celebrations of joy? Do you dance merry jigs or perform elaborate interpretive choreography? Do you focus on one style of performance or strive to master them all?*"
+          "value": "*Does your Bard beat a drum while chanting the deeds of ancient heroes? Strum a lute while crooning romantic tunes? Perform arias of stirring power? Recite dramatic monologues from classic tragedies? Use the rhythm of a folk dance to coordinate the movement of allies in battle? Compose naughty limericks?*\n*When you play a Bard, consider the style of artistic performance you favor, the moods you might invoke, and the themes that inspire your own creations. Are your poems inspired by moments of natural beauty, or are they brooding reflections on loss? Do you prefer lofty hymns or rowdy tavern songs? Are you drawn to laments for the fallen or celebrations of joy? Do you dance merry jigs or perform elaborate interpretive choreography? Do you focus on one style of performance or strive to master them all?*"
         }
       ],
       "3": [
@@ -7383,6 +7433,7 @@
             "name": "Spirit Tales",
             "type": "table",
             "value": {
+              "title": "Spirit Tales",
               "headers": [
                 "Bardic Insp. Die",
                 "Tale Told Through You"
@@ -8118,6 +8169,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8160,6 +8212,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8202,6 +8255,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8244,6 +8298,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8286,6 +8341,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8328,6 +8384,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8370,6 +8427,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8412,6 +8470,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8454,6 +8513,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8496,6 +8556,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8538,6 +8599,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8580,6 +8642,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8622,6 +8685,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8664,6 +8728,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8706,6 +8771,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8748,6 +8814,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8790,6 +8857,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8832,6 +8900,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8874,6 +8943,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -8916,6 +8986,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -9166,7 +9237,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*Does your Bard beat a drum while chanting the deeds of ancient heroes? Strum a lute while crooning romantic tunes? Perform arias of stirring power? Recite dramatic monologues from classic tragedies? Use the rhythm of a folk dance to coordinate the movement of allies in battle? Compose naughty limericks?\n\nWhen you play a Bard, consider the style of artistic performance you favor, the moods you might invoke, and the themes that inspire your own creations. Are your poems inspired by moments of natural beauty, or are they brooding reflections on loss? Do you prefer lofty hymns or rowdy tavern songs? Are you drawn to laments for the fallen or celebrations of joy? Do you dance merry jigs or perform elaborate interpretive choreography? Do you focus on one style of performance or strive to master them all?*"
+          "value": "*Does your Bard beat a drum while chanting the deeds of ancient heroes? Strum a lute while crooning romantic tunes? Perform arias of stirring power? Recite dramatic monologues from classic tragedies? Use the rhythm of a folk dance to coordinate the movement of allies in battle? Compose naughty limericks?*\n*When you play a Bard, consider the style of artistic performance you favor, the moods you might invoke, and the themes that inspire your own creations. Are your poems inspired by moments of natural beauty, or are they brooding reflections on loss? Do you prefer lofty hymns or rowdy tavern songs? Are you drawn to laments for the fallen or celebrations of joy? Do you dance merry jigs or perform elaborate interpretive choreography? Do you focus on one style of performance or strive to master them all?*"
         }
       ],
       "3": [
@@ -9901,6 +9972,7 @@
             "name": "Spirit Tales",
             "type": "table",
             "value": {
+              "title": "Spirit Tales",
               "headers": [
                 "Bardic Insp. Die",
                 "Tale Told Through You"
@@ -10636,6 +10708,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -10678,6 +10751,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -10720,6 +10794,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -10762,6 +10837,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -10804,6 +10880,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -10846,6 +10923,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -10888,6 +10966,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -10930,6 +11009,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -10972,6 +11052,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11014,6 +11095,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11056,6 +11138,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11098,6 +11181,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11140,6 +11224,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11182,6 +11267,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11224,6 +11310,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11266,6 +11353,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11308,6 +11396,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11350,6 +11439,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11392,6 +11482,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11434,6 +11525,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -11995,6 +12087,7 @@
             "name": "Death Domain Spells",
             "type": "table",
             "value": {
+              "title": "Death Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -12099,6 +12192,7 @@
             "name": "Knowledge Domain Spells",
             "type": "table",
             "value": {
+              "title": "Knowledge Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -12233,6 +12327,7 @@
             "name": "Life Domain Spells",
             "type": "table",
             "value": {
+              "title": "Life Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -12342,6 +12437,7 @@
             "name": "Light Domain Spells",
             "type": "table",
             "value": {
+              "title": "Light Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -12456,6 +12552,7 @@
             "name": "Nature Domain Spells",
             "type": "table",
             "value": {
+              "title": "Nature Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -12565,6 +12662,7 @@
             "name": "Tempest Domain Spells",
             "type": "table",
             "value": {
+              "title": "Tempest Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -12674,6 +12772,7 @@
             "name": "Trickery Domain Spells",
             "type": "table",
             "value": {
+              "title": "Trickery Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -12788,6 +12887,7 @@
             "name": "War Domain Spells",
             "type": "table",
             "value": {
+              "title": "War Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -12892,6 +12992,7 @@
             "name": "Ambition Domain Spells",
             "type": "table",
             "value": {
+              "title": "Ambition Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -13035,6 +13136,7 @@
             "name": "Solidarity Domain Spells",
             "type": "table",
             "value": {
+              "title": "Solidarity Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -13149,6 +13251,7 @@
             "name": "Strength Domain Spells",
             "type": "table",
             "value": {
+              "title": "Strength Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -13258,6 +13361,7 @@
             "name": "Zeal Domain Spells",
             "type": "table",
             "value": {
+              "title": "Zeal Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -13382,6 +13486,7 @@
             "name": "Arcana Domain Spells",
             "type": "table",
             "value": {
+              "title": "Arcana Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -13441,6 +13546,7 @@
             "name": "Arcane Banishment",
             "type": "table",
             "value": {
+              "title": "Arcane Banishment",
               "headers": [
                 "Cleric level",
                 "Banishes Creatures of CR..."
@@ -13538,6 +13644,7 @@
             "name": "Order Domain Spells",
             "type": "table",
             "value": {
+              "title": "Order Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -13662,6 +13769,7 @@
             "name": "Peace Deities",
             "type": "table",
             "value": {
+              "title": "Peace Deities",
               "headers": [
                 "Example Deity",
                 "Pantheon"
@@ -13716,6 +13824,7 @@
             "name": "Peace Domain Spells",
             "type": "table",
             "value": {
+              "title": "Peace Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -13860,6 +13969,7 @@
             "name": "Twilight Deities",
             "type": "table",
             "value": {
+              "title": "Twilight Deities",
               "headers": [
                 "Example Deity",
                 "Pantheon"
@@ -13914,6 +14024,7 @@
             "name": "Twilight Domain Spells",
             "type": "table",
             "value": {
+              "title": "Twilight Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -14093,6 +14204,7 @@
             "name": "Blood Domain Spells",
             "type": "table",
             "value": {
+              "title": "Blood Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -14249,6 +14361,7 @@
             "name": "Moon Domain Spells",
             "type": "table",
             "value": {
+              "title": "Moon Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -14353,6 +14466,7 @@
             "name": "Forge Domain Spells",
             "type": "table",
             "value": {
+              "title": "Forge Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -14477,6 +14591,7 @@
             "name": "Grave Domain Spells",
             "type": "table",
             "value": {
+              "title": "Grave Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -14621,6 +14736,7 @@
             "name": "Life Domain Spells",
             "type": "table",
             "value": {
+              "title": "Life Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Prepared Spells"
@@ -14707,6 +14823,7 @@
             "name": "Light Domain Spells",
             "type": "table",
             "value": {
+              "title": "Light Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Prepared Spells"
@@ -14838,6 +14955,7 @@
             "name": "Trickery Domain Spells",
             "type": "table",
             "value": {
+              "title": "Trickery Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Prepared Spells"
@@ -14934,6 +15052,7 @@
             "name": "War Domain Spells",
             "type": "table",
             "value": {
+              "title": "War Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Prepared Spells"
@@ -15016,6 +15135,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15058,6 +15178,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15100,6 +15221,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15142,6 +15264,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15184,6 +15307,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15226,6 +15350,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15268,6 +15393,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15310,6 +15436,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15352,6 +15479,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15394,6 +15522,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15436,6 +15565,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15478,6 +15608,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15520,6 +15651,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15562,6 +15694,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15604,6 +15737,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15646,6 +15780,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15688,6 +15823,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15730,6 +15866,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15772,6 +15909,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -15814,6 +15952,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -16375,6 +16514,7 @@
             "name": "Death Domain Spells",
             "type": "table",
             "value": {
+              "title": "Death Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -16479,6 +16619,7 @@
             "name": "Knowledge Domain Spells",
             "type": "table",
             "value": {
+              "title": "Knowledge Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -16613,6 +16754,7 @@
             "name": "Life Domain Spells",
             "type": "table",
             "value": {
+              "title": "Life Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -16722,6 +16864,7 @@
             "name": "Light Domain Spells",
             "type": "table",
             "value": {
+              "title": "Light Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -16836,6 +16979,7 @@
             "name": "Nature Domain Spells",
             "type": "table",
             "value": {
+              "title": "Nature Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -16945,6 +17089,7 @@
             "name": "Tempest Domain Spells",
             "type": "table",
             "value": {
+              "title": "Tempest Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -17054,6 +17199,7 @@
             "name": "Trickery Domain Spells",
             "type": "table",
             "value": {
+              "title": "Trickery Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -17168,6 +17314,7 @@
             "name": "War Domain Spells",
             "type": "table",
             "value": {
+              "title": "War Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -17272,6 +17419,7 @@
             "name": "Ambition Domain Spells",
             "type": "table",
             "value": {
+              "title": "Ambition Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -17415,6 +17563,7 @@
             "name": "Solidarity Domain Spells",
             "type": "table",
             "value": {
+              "title": "Solidarity Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -17529,6 +17678,7 @@
             "name": "Strength Domain Spells",
             "type": "table",
             "value": {
+              "title": "Strength Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -17638,6 +17788,7 @@
             "name": "Zeal Domain Spells",
             "type": "table",
             "value": {
+              "title": "Zeal Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -17762,6 +17913,7 @@
             "name": "Arcana Domain Spells",
             "type": "table",
             "value": {
+              "title": "Arcana Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -17821,6 +17973,7 @@
             "name": "Arcane Banishment",
             "type": "table",
             "value": {
+              "title": "Arcane Banishment",
               "headers": [
                 "Cleric level",
                 "Banishes Creatures of CR..."
@@ -17918,6 +18071,7 @@
             "name": "Order Domain Spells",
             "type": "table",
             "value": {
+              "title": "Order Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -18042,6 +18196,7 @@
             "name": "Peace Deities",
             "type": "table",
             "value": {
+              "title": "Peace Deities",
               "headers": [
                 "Example Deity",
                 "Pantheon"
@@ -18096,6 +18251,7 @@
             "name": "Peace Domain Spells",
             "type": "table",
             "value": {
+              "title": "Peace Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -18240,6 +18396,7 @@
             "name": "Twilight Deities",
             "type": "table",
             "value": {
+              "title": "Twilight Deities",
               "headers": [
                 "Example Deity",
                 "Pantheon"
@@ -18294,6 +18451,7 @@
             "name": "Twilight Domain Spells",
             "type": "table",
             "value": {
+              "title": "Twilight Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -18473,6 +18631,7 @@
             "name": "Blood Domain Spells",
             "type": "table",
             "value": {
+              "title": "Blood Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -18629,6 +18788,7 @@
             "name": "Moon Domain Spells",
             "type": "table",
             "value": {
+              "title": "Moon Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -18733,6 +18893,7 @@
             "name": "Forge Domain Spells",
             "type": "table",
             "value": {
+              "title": "Forge Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -18857,6 +19018,7 @@
             "name": "Grave Domain Spells",
             "type": "table",
             "value": {
+              "title": "Grave Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Spells"
@@ -19001,6 +19163,7 @@
             "name": "Life Domain Spells",
             "type": "table",
             "value": {
+              "title": "Life Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Prepared Spells"
@@ -19087,6 +19250,7 @@
             "name": "Light Domain Spells",
             "type": "table",
             "value": {
+              "title": "Light Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Prepared Spells"
@@ -19218,6 +19382,7 @@
             "name": "Trickery Domain Spells",
             "type": "table",
             "value": {
+              "title": "Trickery Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Prepared Spells"
@@ -19314,6 +19479,7 @@
             "name": "War Domain Spells",
             "type": "table",
             "value": {
+              "title": "War Domain Spells",
               "headers": [
                 "Cleric Level",
                 "Prepared Spells"
@@ -19396,6 +19562,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19438,6 +19605,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19480,6 +19648,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19522,6 +19691,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19564,6 +19734,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19606,6 +19777,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19648,6 +19820,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19690,6 +19863,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19732,6 +19906,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19774,6 +19949,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19816,6 +19992,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19858,6 +20035,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19900,6 +20078,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19942,6 +20121,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -19984,6 +20164,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -20026,6 +20207,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -20068,6 +20250,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -20110,6 +20293,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -20152,6 +20336,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -20194,6 +20379,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -20430,6 +20616,7 @@
           "name": "Beast Shapes",
           "type": "table",
           "value": {
+            "title": "Beast Shapes",
             "headers": [
               "Level",
               "Max. CR",
@@ -20502,6 +20689,7 @@
           "name": "Beast Shapes",
           "type": "table",
           "value": {
+            "title": "Beast Shapes",
             "headers": [
               "Druid Level",
               "Known Forms",
@@ -20837,6 +21025,7 @@
             "name": "Arctic",
             "type": "table",
             "value": {
+              "title": "Arctic",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -20865,6 +21054,7 @@
             "name": "Coast",
             "type": "table",
             "value": {
+              "title": "Coast",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -20893,6 +21083,7 @@
             "name": "Desert",
             "type": "table",
             "value": {
+              "title": "Desert",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -20921,6 +21112,7 @@
             "name": "Forest",
             "type": "table",
             "value": {
+              "title": "Forest",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -20949,6 +21141,7 @@
             "name": "Grassland",
             "type": "table",
             "value": {
+              "title": "Grassland",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -20977,6 +21170,7 @@
             "name": "Mountain",
             "type": "table",
             "value": {
+              "title": "Mountain",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -21005,6 +21199,7 @@
             "name": "Swamp",
             "type": "table",
             "value": {
+              "title": "Swamp",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -21033,6 +21228,7 @@
             "name": "Underdark",
             "type": "table",
             "value": {
+              "title": "Underdark",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -21136,6 +21332,7 @@
             "name": "Circle of the Moon Beast Shapes",
             "type": "table",
             "value": {
+              "title": "Circle of the Moon Beast Shapes",
               "headers": [
                 "Level",
                 "Max. CR",
@@ -21264,6 +21461,7 @@
             "name": "Circle of Spores Spells",
             "type": "table",
             "value": {
+              "title": "Circle of Spores Spells",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -21402,6 +21600,7 @@
             "name": "Star Map",
             "type": "table",
             "value": {
+              "title": "Star Map",
               "headers": [
                 "d6",
                 "Map Form"
@@ -21573,6 +21772,7 @@
             "name": "Circle of Wildfire Spells",
             "type": "table",
             "value": {
+              "title": "Circle of Wildfire Spells",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -21774,6 +21974,7 @@
             "name": "Toxic Demise Damage",
             "type": "table",
             "value": {
+              "title": "Toxic Demise Damage",
               "headers": [
                 "Creature CR",
                 "Damage"
@@ -21789,11 +21990,11 @@
                 ],
                 [
                   "1 or higher",
-                  "(#$prompt_number:min=1,title=Enter the creature's CR!,default=1$#)d8|A number of d8s of necrotic damage equal to the creature's challenge rating"
+                  "A number of d8s of necrotic damage equal to the creature's challenge rating"
                 ],
                 [
                   "No challenge rating",
-                  "(#$prompt_number:min=1,title=Enter your Proficiency Bonus!,default=1$#)d6|A number of d6s of necrotic damage equal to your proficiency bonus"
+                  "A number of d6s of necrotic damage equal to your proficiency bonus"
                 ]
               ]
             }
@@ -22028,6 +22229,7 @@
             "name": "Arid Land",
             "type": "table",
             "value": {
+              "title": "Arid Land",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -22056,6 +22258,7 @@
             "name": "Polar Land",
             "type": "table",
             "value": {
+              "title": "Polar Land",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -22084,6 +22287,7 @@
             "name": "Temperate Land",
             "type": "table",
             "value": {
+              "title": "Temperate Land",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -22112,6 +22316,7 @@
             "name": "Tropical Land",
             "type": "table",
             "value": {
+              "title": "Tropical Land",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -22169,6 +22374,7 @@
             "name": "Nature's Ward",
             "type": "table",
             "value": {
+              "title": "Nature's Ward",
               "headers": [
                 "Land Type",
                 "Resistance"
@@ -22268,6 +22474,7 @@
             "name": "Circle of the Moon Spells",
             "type": "table",
             "value": {
+              "title": "Circle of the Moon Spells",
               "headers": [
                 "Druid Level",
                 "Prepared Spells"
@@ -22371,6 +22578,7 @@
             "name": "Circle of the Sea Spells",
             "type": "table",
             "value": {
+              "title": "Circle of the Sea Spells",
               "headers": [
                 "Druid Level",
                 "Prepared Spells"
@@ -22489,6 +22697,7 @@
             "name": "Star Map",
             "type": "table",
             "value": {
+              "title": "Star Map",
               "headers": [
                 "1d6",
                 "Map Form"
@@ -22641,6 +22850,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -22683,6 +22893,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -22725,6 +22936,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -22767,6 +22979,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -22809,6 +23022,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -22851,6 +23065,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -22893,6 +23108,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -22935,6 +23151,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -22977,6 +23194,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23019,6 +23237,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23061,6 +23280,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23103,6 +23323,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23145,6 +23366,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23187,6 +23409,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23229,6 +23452,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23271,6 +23495,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23313,6 +23538,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23355,6 +23581,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23397,6 +23624,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23439,6 +23667,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -23675,6 +23904,7 @@
           "name": "Beast Shapes",
           "type": "table",
           "value": {
+            "title": "Beast Shapes",
             "headers": [
               "Level",
               "Max. CR",
@@ -23747,6 +23977,7 @@
           "name": "Beast Shapes",
           "type": "table",
           "value": {
+            "title": "Beast Shapes",
             "headers": [
               "Druid Level",
               "Known Forms",
@@ -24082,6 +24313,7 @@
             "name": "Arctic",
             "type": "table",
             "value": {
+              "title": "Arctic",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -24110,6 +24342,7 @@
             "name": "Coast",
             "type": "table",
             "value": {
+              "title": "Coast",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -24138,6 +24371,7 @@
             "name": "Desert",
             "type": "table",
             "value": {
+              "title": "Desert",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -24166,6 +24400,7 @@
             "name": "Forest",
             "type": "table",
             "value": {
+              "title": "Forest",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -24194,6 +24429,7 @@
             "name": "Grassland",
             "type": "table",
             "value": {
+              "title": "Grassland",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -24222,6 +24458,7 @@
             "name": "Mountain",
             "type": "table",
             "value": {
+              "title": "Mountain",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -24250,6 +24487,7 @@
             "name": "Swamp",
             "type": "table",
             "value": {
+              "title": "Swamp",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -24278,6 +24516,7 @@
             "name": "Underdark",
             "type": "table",
             "value": {
+              "title": "Underdark",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -24381,6 +24620,7 @@
             "name": "Circle of the Moon Beast Shapes",
             "type": "table",
             "value": {
+              "title": "Circle of the Moon Beast Shapes",
               "headers": [
                 "Level",
                 "Max. CR",
@@ -24509,6 +24749,7 @@
             "name": "Circle of Spores Spells",
             "type": "table",
             "value": {
+              "title": "Circle of Spores Spells",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -24647,6 +24888,7 @@
             "name": "Star Map",
             "type": "table",
             "value": {
+              "title": "Star Map",
               "headers": [
                 "d6",
                 "Map Form"
@@ -24818,6 +25060,7 @@
             "name": "Circle of Wildfire Spells",
             "type": "table",
             "value": {
+              "title": "Circle of Wildfire Spells",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -25019,6 +25262,7 @@
             "name": "Toxic Demise Damage",
             "type": "table",
             "value": {
+              "title": "Toxic Demise Damage",
               "headers": [
                 "Creature CR",
                 "Damage"
@@ -25034,11 +25278,11 @@
                 ],
                 [
                   "1 or higher",
-                  "(#$prompt_number:min=1,title=Enter the creature's CR!,default=1$#)d8|A number of d8s of necrotic damage equal to the creature's challenge rating"
+                  "A number of d8s of necrotic damage equal to the creature's challenge rating"
                 ],
                 [
                   "No challenge rating",
-                  "(#$prompt_number:min=1,title=Enter your Proficiency Bonus!,default=1$#)d6|A number of d6s of necrotic damage equal to your proficiency bonus"
+                  "A number of d6s of necrotic damage equal to your proficiency bonus"
                 ]
               ]
             }
@@ -25273,6 +25517,7 @@
             "name": "Arid Land",
             "type": "table",
             "value": {
+              "title": "Arid Land",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -25301,6 +25546,7 @@
             "name": "Polar Land",
             "type": "table",
             "value": {
+              "title": "Polar Land",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -25329,6 +25575,7 @@
             "name": "Temperate Land",
             "type": "table",
             "value": {
+              "title": "Temperate Land",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -25357,6 +25604,7 @@
             "name": "Tropical Land",
             "type": "table",
             "value": {
+              "title": "Tropical Land",
               "headers": [
                 "Druid Level",
                 "Circle Spells"
@@ -25414,6 +25662,7 @@
             "name": "Nature's Ward",
             "type": "table",
             "value": {
+              "title": "Nature's Ward",
               "headers": [
                 "Land Type",
                 "Resistance"
@@ -25513,6 +25762,7 @@
             "name": "Circle of the Moon Spells",
             "type": "table",
             "value": {
+              "title": "Circle of the Moon Spells",
               "headers": [
                 "Druid Level",
                 "Prepared Spells"
@@ -25616,6 +25866,7 @@
             "name": "Circle of the Sea Spells",
             "type": "table",
             "value": {
+              "title": "Circle of the Sea Spells",
               "headers": [
                 "Druid Level",
                 "Prepared Spells"
@@ -25734,6 +25985,7 @@
             "name": "Star Map",
             "type": "table",
             "value": {
+              "title": "Star Map",
               "headers": [
                 "1d6",
                 "Map Form"
@@ -27063,6 +27315,7 @@
             "name": "Runes Known",
             "type": "table",
             "value": {
+              "title": "Runes Known",
               "headers": [
                 "Fighter Level",
                 "Number of Runes"
@@ -27795,6 +28048,7 @@
             "name": "Psi Warrior Energy Dice",
             "type": "table",
             "value": {
+              "title": "Psi Warrior Energy Dice",
               "headers": [
                 "Fighter Level",
                 "Die Size",
@@ -29248,6 +29502,7 @@
             "name": "Runes Known",
             "type": "table",
             "value": {
+              "title": "Runes Known",
               "headers": [
                 "Fighter Level",
                 "Number of Runes"
@@ -29980,6 +30235,7 @@
             "name": "Psi Warrior Energy Dice",
             "type": "table",
             "value": {
+              "title": "Psi Warrior Energy Dice",
               "headers": [
                 "Fighter Level",
                 "Die Size",
@@ -30901,6 +31157,7 @@
             "name": "Ascendant Dragon Origin",
             "type": "table",
             "value": {
+              "title": "Ascendant Dragon Origin",
               "headers": [
                 "d6",
                 "Origin"
@@ -31082,6 +31339,7 @@
             "name": "Spells and Ki Points",
             "type": "table",
             "value": {
+              "title": "Spells and Ki Points",
               "headers": [
                 "Monk Levels",
                 "Maximum Ki Points for a Spell"
@@ -31505,6 +31763,7 @@
             "name": "Merciful Mask",
             "type": "table",
             "value": {
+              "title": "Merciful Mask",
               "headers": [
                 "d6",
                 "Mask Appearance"
@@ -33027,6 +33286,7 @@
             "name": "Ascendant Dragon Origin",
             "type": "table",
             "value": {
+              "title": "Ascendant Dragon Origin",
               "headers": [
                 "d6",
                 "Origin"
@@ -33208,6 +33468,7 @@
             "name": "Spells and Ki Points",
             "type": "table",
             "value": {
+              "title": "Spells and Ki Points",
               "headers": [
                 "Monk Levels",
                 "Maximum Ki Points for a Spell"
@@ -33631,6 +33892,7 @@
             "name": "Merciful Mask",
             "type": "table",
             "value": {
+              "title": "Merciful Mask",
               "headers": [
                 "d6",
                 "Mask Appearance"
@@ -35167,6 +35429,7 @@
             "name": "",
             "type": "table",
             "value": {
+              "title": "",
               "headers": [
                 "Psi Points",
                 "Attack and Damage Bonus"
@@ -35268,6 +35531,7 @@
             "name": "",
             "type": "table",
             "value": {
+              "title": "",
               "headers": [
                 "Spell Slot Level",
                 "Psi Cost"
@@ -35342,6 +35606,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35366,6 +35631,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35390,6 +35656,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35414,6 +35681,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35438,6 +35706,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35462,6 +35731,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35486,6 +35756,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35510,6 +35781,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35534,6 +35806,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35558,6 +35831,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35582,6 +35856,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35606,6 +35881,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35630,6 +35906,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35654,6 +35931,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35678,6 +35956,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35702,6 +35981,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35726,6 +36006,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35750,6 +36031,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35774,6 +36056,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -35798,6 +36081,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -36047,7 +36331,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*A paladin tries to hold to the highest standards of conduct, but even the most virtuous paladin is fallible. Sometimes the right path proves too demanding, sometimes a situation calls for the lesser of two evils, and sometimes the heat of emotion causes a paladin to transgress his or her oath.\n\nA paladin who has broken a vow typically seeks absolution from a cleric who shares his or her faith or from another paladin of the same order. The paladin might spend an all-night vigil in prayer as a sign of penitence, or undertake a fast or similar act of self-denial. After a rite of confession and forgiveness, the paladin starts fresh.\n\nIf a paladin willfully violates his or her oath and shows no sign of repentance, the consequences can be more serious. At the DM's discretion, an impenitent paladin might be forced to abandon this class and adopt another, or perhaps to take the Oathbreaker paladin option that appears in the Dungeon Master's Guide.*"
+          "value": "*A paladin tries to hold to the highest standards of conduct, but even the most virtuous paladin is fallible. Sometimes the right path proves too demanding, sometimes a situation calls for the lesser of two evils, and sometimes the heat of emotion causes a paladin to transgress his or her oath.*\n*A paladin who has broken a vow typically seeks absolution from a cleric who shares his or her faith or from another paladin of the same order. The paladin might spend an all-night vigil in prayer as a sign of penitence, or undertake a fast or similar act of self-denial. After a rite of confession and forgiveness, the paladin starts fresh.*\n*If a paladin willfully violates his or her oath and shows no sign of repentance, the consequences can be more serious. At the DM's discretion, an impenitent paladin might be forced to abandon this class and adopt another, or perhaps to take the Oathbreaker paladin option that appears in the Dungeon Master's Guide.*"
         },
         {
           "name": "Oath Spells",
@@ -36092,7 +36376,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*A Paladin tries to hold to the highest standards of conduct, but even the most dedicated are fallible. Sometimes a Paladin transgresses their oath.\n\nA Paladin who has broken a vow typically seeks absolution, spending an all-night vigil as a sign of penitence or undertaking a fast. After a rite of forgiveness, the Paladin starts fresh.\n\nIf your Paladin unrepentantly violates their oath, talk to your DM. Your Paladin should probably take a more appropriate subclass or even abandon the class and adopt another one.*"
+          "value": "*A Paladin tries to hold to the highest standards of conduct, but even the most dedicated are fallible. Sometimes a Paladin transgresses their oath.*\n*A Paladin who has broken a vow typically seeks absolution, spending an all-night vigil as a sign of penitence or undertaking a fast. After a rite of forgiveness, the Paladin starts fresh.*\n*If your Paladin unrepentantly violates their oath, talk to your DM. Your Paladin should probably take a more appropriate subclass or even abandon the class and adopt another one.*"
         }
       ],
       "4": [
@@ -36398,6 +36682,7 @@
             "name": "Oathbreaker Spells",
             "type": "table",
             "value": {
+              "title": "Oathbreaker Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -36515,6 +36800,7 @@
             "name": "Oath of the Ancients Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Ancients Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -36677,6 +36963,7 @@
             "name": "Oath of Devotion Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Devotion Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -36859,6 +37146,7 @@
             "name": "Oath of Vengeance Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Vengeance Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -37001,6 +37289,7 @@
             "name": "Oath of the Crown Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Crown Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -37148,6 +37437,7 @@
             "name": "Oath of Glory Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Glory Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -37330,6 +37620,7 @@
             "name": "Oath of the Watchers Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Watchers Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -37491,7 +37782,7 @@
           {
             "name": "",
             "type": "text",
-            "value": "*Fog and other effects can obscure vision for you, your enemies, and your allies. When you heavily obscure an area using your Marine Layer Channel Divinity option, all creatures within the area have their vision completely blocked, and creatures outside the area can't see in. Creatures that can't see automatically fail ability checks that require sight. Also, attack rolls against creatures that can't see have Advantage and Disadvantage, and their own attack rolls have Advantage and Disadvantage.\n\nCreatures in a lightly obscured area have Advantage and Disadvantage only on Wisdom (*Perception*) checks that rely on sight. The rules for when your vision is obscured are described completely in the fifth edition core rules.*"
+            "value": "*Fog and other effects can obscure vision for you, your enemies, and your allies. When you heavily obscure an area using your Marine Layer Channel Divinity option, all creatures within the area have their vision completely blocked, and creatures outside the area can't see in. Creatures that can't see automatically fail ability checks that require sight. Also, attack rolls against creatures that can't see have Advantage and Disadvantage, and their own attack rolls have Advantage and Disadvantage.*\n*Creatures in a lightly obscured area have Advantage and Disadvantage only on Wisdom (*Perception*) checks that rely on sight. The rules for when your vision is obscured are described completely in the fifth edition core rules.*"
           },
           {
             "name": "",
@@ -37512,6 +37803,7 @@
             "name": "Oath of the Open Sea Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Open Sea Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -37666,6 +37958,7 @@
             "name": "Oath of Conquest Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Conquest Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -37813,6 +38106,7 @@
             "name": "Oath of Redemption Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Redemption Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -37955,6 +38249,7 @@
             "name": "Oath of the Ancients Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Ancients Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -38072,6 +38367,7 @@
             "name": "Oath of Devotion Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Devotion Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -38204,6 +38500,7 @@
             "name": "Oath of Glory Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Glory Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -38326,6 +38623,7 @@
             "name": "Oath of Vengeance Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Vengeance Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -38434,6 +38732,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38468,6 +38767,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38502,6 +38802,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38536,6 +38837,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38570,6 +38872,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38604,6 +38907,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38638,6 +38942,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38672,6 +38977,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38706,6 +39012,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38740,6 +39047,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38774,6 +39082,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38808,6 +39117,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38842,6 +39152,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38876,6 +39187,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38910,6 +39222,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38944,6 +39257,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -38978,6 +39292,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -39012,6 +39327,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -39046,6 +39362,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -39080,6 +39397,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -39339,7 +39657,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*A paladin tries to hold to the highest standards of conduct, but even the most virtuous paladin is fallible. Sometimes the right path proves too demanding, sometimes a situation calls for the lesser of two evils, and sometimes the heat of emotion causes a paladin to transgress his or her oath.\n\nA paladin who has broken a vow typically seeks absolution from a cleric who shares his or her faith or from another paladin of the same order. The paladin might spend an all-night vigil in prayer as a sign of penitence, or undertake a fast or similar act of self-denial. After a rite of confession and forgiveness, the paladin starts fresh.\n\nIf a paladin willfully violates his or her oath and shows no sign of repentance, the consequences can be more serious. At the DM's discretion, an impenitent paladin might be forced to abandon this class and adopt another, or perhaps to take the Oathbreaker paladin option that appears in the Dungeon Master's Guide.*"
+          "value": "*A paladin tries to hold to the highest standards of conduct, but even the most virtuous paladin is fallible. Sometimes the right path proves too demanding, sometimes a situation calls for the lesser of two evils, and sometimes the heat of emotion causes a paladin to transgress his or her oath.*\n*A paladin who has broken a vow typically seeks absolution from a cleric who shares his or her faith or from another paladin of the same order. The paladin might spend an all-night vigil in prayer as a sign of penitence, or undertake a fast or similar act of self-denial. After a rite of confession and forgiveness, the paladin starts fresh.*\n*If a paladin willfully violates his or her oath and shows no sign of repentance, the consequences can be more serious. At the DM's discretion, an impenitent paladin might be forced to abandon this class and adopt another, or perhaps to take the Oathbreaker paladin option that appears in the Dungeon Master's Guide.*"
         },
         {
           "name": "Oath Spells",
@@ -39384,7 +39702,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*A Paladin tries to hold to the highest standards of conduct, but even the most dedicated are fallible. Sometimes a Paladin transgresses their oath.\n\nA Paladin who has broken a vow typically seeks absolution, spending an all-night vigil as a sign of penitence or undertaking a fast. After a rite of forgiveness, the Paladin starts fresh.\n\nIf your Paladin unrepentantly violates their oath, talk to your DM. Your Paladin should probably take a more appropriate subclass or even abandon the class and adopt another one.*"
+          "value": "*A Paladin tries to hold to the highest standards of conduct, but even the most dedicated are fallible. Sometimes a Paladin transgresses their oath.*\n*A Paladin who has broken a vow typically seeks absolution, spending an all-night vigil as a sign of penitence or undertaking a fast. After a rite of forgiveness, the Paladin starts fresh.*\n*If your Paladin unrepentantly violates their oath, talk to your DM. Your Paladin should probably take a more appropriate subclass or even abandon the class and adopt another one.*"
         }
       ],
       "4": [
@@ -39690,6 +40008,7 @@
             "name": "Oathbreaker Spells",
             "type": "table",
             "value": {
+              "title": "Oathbreaker Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -39807,6 +40126,7 @@
             "name": "Oath of the Ancients Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Ancients Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -39969,6 +40289,7 @@
             "name": "Oath of Devotion Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Devotion Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -40151,6 +40472,7 @@
             "name": "Oath of Vengeance Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Vengeance Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -40293,6 +40615,7 @@
             "name": "Oath of the Crown Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Crown Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -40440,6 +40763,7 @@
             "name": "Oath of Glory Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Glory Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -40622,6 +40946,7 @@
             "name": "Oath of the Watchers Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Watchers Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -40783,7 +41108,7 @@
           {
             "name": "",
             "type": "text",
-            "value": "*Fog and other effects can obscure vision for you, your enemies, and your allies. When you heavily obscure an area using your Marine Layer Channel Divinity option, all creatures within the area have their vision completely blocked, and creatures outside the area can't see in. Creatures that can't see automatically fail ability checks that require sight. Also, attack rolls against creatures that can't see have Advantage and Disadvantage, and their own attack rolls have Advantage and Disadvantage.\n\nCreatures in a lightly obscured area have Advantage and Disadvantage only on Wisdom (*Perception*) checks that rely on sight. The rules for when your vision is obscured are described completely in the fifth edition core rules.*"
+            "value": "*Fog and other effects can obscure vision for you, your enemies, and your allies. When you heavily obscure an area using your Marine Layer Channel Divinity option, all creatures within the area have their vision completely blocked, and creatures outside the area can't see in. Creatures that can't see automatically fail ability checks that require sight. Also, attack rolls against creatures that can't see have Advantage and Disadvantage, and their own attack rolls have Advantage and Disadvantage.*\n*Creatures in a lightly obscured area have Advantage and Disadvantage only on Wisdom (*Perception*) checks that rely on sight. The rules for when your vision is obscured are described completely in the fifth edition core rules.*"
           },
           {
             "name": "",
@@ -40804,6 +41129,7 @@
             "name": "Oath of the Open Sea Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Open Sea Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -40958,6 +41284,7 @@
             "name": "Oath of Conquest Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Conquest Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -41105,6 +41432,7 @@
             "name": "Oath of Redemption Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Redemption Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -41247,6 +41575,7 @@
             "name": "Oath of the Ancients Spells",
             "type": "table",
             "value": {
+              "title": "Oath of the Ancients Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -41364,6 +41693,7 @@
             "name": "Oath of Devotion Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Devotion Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -41496,6 +41826,7 @@
             "name": "Oath of Glory Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Glory Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -41618,6 +41949,7 @@
             "name": "Oath of Vengeance Spells",
             "type": "table",
             "value": {
+              "title": "Oath of Vengeance Spells",
               "headers": [
                 "Paladin Level",
                 "Spells"
@@ -41726,6 +42058,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -41760,6 +42093,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -41794,6 +42128,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -41828,6 +42163,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -41862,6 +42198,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -41896,6 +42233,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -41930,6 +42268,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -41964,6 +42303,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -41998,6 +42338,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42032,6 +42373,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42066,6 +42408,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42100,6 +42443,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42134,6 +42478,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42168,6 +42513,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42202,6 +42548,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42236,6 +42583,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42270,6 +42618,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42304,6 +42653,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42338,6 +42688,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42372,6 +42723,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -42667,6 +43019,7 @@
           "name": "Primal Awareness Spells",
           "type": "table",
           "value": {
+            "title": "Primal Awareness Spells",
             "headers": [
               "Ranger Level",
               "Spell"
@@ -43048,6 +43401,7 @@
             "name": "Drakewarden Origin",
             "type": "table",
             "value": {
+              "title": "Drakewarden Origin",
               "headers": [
                 "d6",
                 "Origin"
@@ -43449,6 +43803,7 @@
             "name": "Fey Wanderer Spells",
             "type": "table",
             "value": {
+              "title": "Fey Wanderer Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -43481,6 +43836,7 @@
             "name": "Feywild Gifts",
             "type": "table",
             "value": {
+              "title": "Feywild Gifts",
               "headers": [
                 "d6",
                 "Gift"
@@ -43621,12 +43977,13 @@
           {
             "name": "",
             "type": "text",
-            "value": "*A Swarmkeeper's swarm and spells are reflections of the character's bond with nature spirits. Take the opportunity to describe the swarm and the ranger's magic in play. For example, when your ranger casts gaseous form, they might appear to melt into the swarm, instead of a cloud of mist, or the __arcane eye__ spell could create an extension of your swarm that spies for you. Such descriptions don't change the effects of spells, but they are an exciting opportunity to explore your character's narrative through their class abilities. For more guidance on customizing spells, see the \"Personalizing Spells\" section in chapter 3.\n\nAlso, remember that the swarm's appearance is yours to customize, and don't feel confined to a single appearance. Perhaps the spirits' look changes with the ranger's mood or with the seasons. You decide!*"
+            "value": "*A Swarmkeeper's swarm and spells are reflections of the character's bond with nature spirits. Take the opportunity to describe the swarm and the ranger's magic in play. For example, when your ranger casts gaseous form, they might appear to melt into the swarm, instead of a cloud of mist, or the __arcane eye__ spell could create an extension of your swarm that spies for you. Such descriptions don't change the effects of spells, but they are an exciting opportunity to explore your character's narrative through their class abilities. For more guidance on customizing spells, see the \"Personalizing Spells\" section in chapter 3.*\n*Also, remember that the swarm's appearance is yours to customize, and don't feel confined to a single appearance. Perhaps the spirits' look changes with the ranger's mood or with the seasons. You decide!*"
           },
           {
             "name": "Swarm Appearance",
             "type": "table",
             "value": {
+              "title": "Swarm Appearance",
               "headers": [
                 "d4",
                 "Appearance"
@@ -43670,6 +44027,7 @@
             "name": "Swarmkeeper Spells",
             "type": "table",
             "value": {
+              "title": "Swarmkeeper Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -43792,6 +44150,7 @@
             "name": "Gloom Stalker Spells",
             "type": "table",
             "value": {
+              "title": "Gloom Stalker Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -43899,6 +44258,7 @@
             "name": "Horizon Walker Spells",
             "type": "table",
             "value": {
+              "title": "Horizon Walker Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -44011,6 +44371,7 @@
             "name": "Monster Slayer Spells",
             "type": "table",
             "value": {
+              "title": "Monster Slayer Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -44198,6 +44559,7 @@
             "name": "Fey Wanderer Spells",
             "type": "table",
             "value": {
+              "title": "Fey Wanderer Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -44230,6 +44592,7 @@
             "name": "Feywild Gifts",
             "type": "table",
             "value": {
+              "title": "Feywild Gifts",
               "headers": [
                 "1d6",
                 "Gift"
@@ -44366,6 +44729,7 @@
             "name": "Gloom Stalker Spells",
             "type": "table",
             "value": {
+              "title": "Gloom Stalker Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -44549,6 +44913,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44583,6 +44948,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44617,6 +44983,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44651,6 +45018,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44685,6 +45053,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44719,6 +45088,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44753,6 +45123,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44787,6 +45158,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44821,6 +45193,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44855,6 +45228,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44889,6 +45263,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44923,6 +45298,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44957,6 +45333,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -44991,6 +45368,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -45025,6 +45403,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -45059,6 +45438,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -45093,6 +45473,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -45127,6 +45508,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -45161,6 +45543,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -45195,6 +45578,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -45490,6 +45874,7 @@
           "name": "Primal Awareness Spells",
           "type": "table",
           "value": {
+            "title": "Primal Awareness Spells",
             "headers": [
               "Ranger Level",
               "Spell"
@@ -45871,6 +46256,7 @@
             "name": "Drakewarden Origin",
             "type": "table",
             "value": {
+              "title": "Drakewarden Origin",
               "headers": [
                 "d6",
                 "Origin"
@@ -46272,6 +46658,7 @@
             "name": "Fey Wanderer Spells",
             "type": "table",
             "value": {
+              "title": "Fey Wanderer Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -46304,6 +46691,7 @@
             "name": "Feywild Gifts",
             "type": "table",
             "value": {
+              "title": "Feywild Gifts",
               "headers": [
                 "d6",
                 "Gift"
@@ -46444,12 +46832,13 @@
           {
             "name": "",
             "type": "text",
-            "value": "*A Swarmkeeper's swarm and spells are reflections of the character's bond with nature spirits. Take the opportunity to describe the swarm and the ranger's magic in play. For example, when your ranger casts gaseous form, they might appear to melt into the swarm, instead of a cloud of mist, or the __arcane eye__ spell could create an extension of your swarm that spies for you. Such descriptions don't change the effects of spells, but they are an exciting opportunity to explore your character's narrative through their class abilities. For more guidance on customizing spells, see the \"Personalizing Spells\" section in chapter 3.\n\nAlso, remember that the swarm's appearance is yours to customize, and don't feel confined to a single appearance. Perhaps the spirits' look changes with the ranger's mood or with the seasons. You decide!*"
+            "value": "*A Swarmkeeper's swarm and spells are reflections of the character's bond with nature spirits. Take the opportunity to describe the swarm and the ranger's magic in play. For example, when your ranger casts gaseous form, they might appear to melt into the swarm, instead of a cloud of mist, or the __arcane eye__ spell could create an extension of your swarm that spies for you. Such descriptions don't change the effects of spells, but they are an exciting opportunity to explore your character's narrative through their class abilities. For more guidance on customizing spells, see the \"Personalizing Spells\" section in chapter 3.*\n*Also, remember that the swarm's appearance is yours to customize, and don't feel confined to a single appearance. Perhaps the spirits' look changes with the ranger's mood or with the seasons. You decide!*"
           },
           {
             "name": "Swarm Appearance",
             "type": "table",
             "value": {
+              "title": "Swarm Appearance",
               "headers": [
                 "d4",
                 "Appearance"
@@ -46493,6 +46882,7 @@
             "name": "Swarmkeeper Spells",
             "type": "table",
             "value": {
+              "title": "Swarmkeeper Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -46615,6 +47005,7 @@
             "name": "Gloom Stalker Spells",
             "type": "table",
             "value": {
+              "title": "Gloom Stalker Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -46722,6 +47113,7 @@
             "name": "Horizon Walker Spells",
             "type": "table",
             "value": {
+              "title": "Horizon Walker Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -46834,6 +47226,7 @@
             "name": "Monster Slayer Spells",
             "type": "table",
             "value": {
+              "title": "Monster Slayer Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -47021,6 +47414,7 @@
             "name": "Fey Wanderer Spells",
             "type": "table",
             "value": {
+              "title": "Fey Wanderer Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -47053,6 +47447,7 @@
             "name": "Feywild Gifts",
             "type": "table",
             "value": {
+              "title": "Feywild Gifts",
               "headers": [
                 "1d6",
                 "Gift"
@@ -47189,6 +47584,7 @@
             "name": "Gloom Stalker Spells",
             "type": "table",
             "value": {
+              "title": "Gloom Stalker Spells",
               "headers": [
                 "Ranger Level",
                 "Spells"
@@ -48962,6 +49358,7 @@
             "name": "Soulknife Energy Dice",
             "type": "table",
             "value": {
+              "title": "Soulknife Energy Dice",
               "headers": [
                 "Rogue Level",
                 "Die Size",
@@ -50806,6 +51203,7 @@
             "name": "Soulknife Energy Dice",
             "type": "table",
             "value": {
+              "title": "Soulknife Energy Dice",
               "headers": [
                 "Rogue Level",
                 "Die Size",
@@ -51136,6 +51534,7 @@
           "name": "Spellcasting",
           "type": "table",
           "value": {
+            "title": "Spellcasting",
             "headers": [
               "Role",
               "Spell List",
@@ -52115,6 +52514,7 @@
           "name": "Spellcasting",
           "type": "table",
           "value": {
+            "title": "Spellcasting",
             "headers": [
               "Role",
               "Spell List",
@@ -52874,6 +53274,7 @@
           "name": "Spellcasting",
           "type": "table",
           "value": {
+            "title": "Spellcasting",
             "headers": [
               "Role",
               "Spell List",
@@ -53557,6 +53958,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53599,6 +54001,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53641,6 +54044,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53683,6 +54087,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53725,6 +54130,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53767,6 +54173,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53809,6 +54216,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53851,6 +54259,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53893,6 +54302,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53935,6 +54345,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -53977,6 +54388,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54019,6 +54431,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54061,6 +54474,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54103,6 +54517,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54145,6 +54560,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54187,6 +54603,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54229,6 +54646,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54271,6 +54689,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54313,6 +54732,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54355,6 +54775,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -54541,6 +54962,7 @@
           "name": "Creating Spell Slots",
           "type": "table",
           "value": {
+            "title": "Creating Spell Slots",
             "headers": [
               "Spell Slot Level",
               "Sorcery Point Cost"
@@ -54628,6 +55050,7 @@
           "name": "Creating Spell Slots",
           "type": "table",
           "value": {
+            "title": "Creating Spell Slots",
             "headers": [
               "Spell Slot Level",
               "Sorcery Point Cost",
@@ -54989,6 +55412,7 @@
             "name": "Lunar Spells",
             "type": "table",
             "value": {
+              "title": "Lunar Spells",
               "headers": [
                 "Sorcerer Level",
                 "Full Moon Spell",
@@ -55158,6 +55582,7 @@
             "name": "Draconic Ancestry",
             "type": "table",
             "value": {
+              "title": "Draconic Ancestry",
               "headers": [
                 "Dragon",
                 "Damage Type"
@@ -55275,6 +55700,7 @@
             "name": "Wild Magic Surge",
             "type": "table",
             "value": {
+              "title": "Wild Magic Surge",
               "headers": [
                 "d100",
                 "Effect"
@@ -55572,6 +55998,7 @@
             "name": "Aberrant Origins",
             "type": "table",
             "value": {
+              "title": "Aberrant Origins",
               "headers": [
                 "d6",
                 "Origin"
@@ -55623,6 +56050,7 @@
             "name": "Psionic Spells",
             "type": "table",
             "value": {
+              "title": "Psionic Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -55770,6 +56198,7 @@
             "name": "Clockwork Spells",
             "type": "table",
             "value": {
+              "title": "Clockwork Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -55802,6 +56231,7 @@
             "name": "Manifestations of Order",
             "type": "table",
             "value": {
+              "title": "Manifestations of Order",
               "headers": [
                 "d6",
                 "Manifestation"
@@ -55978,6 +56408,7 @@
             "name": "Runic Spells",
             "type": "table",
             "value": {
+              "title": "Runic Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -56120,6 +56551,7 @@
             "name": "",
             "type": "table",
             "value": {
+              "title": "",
               "headers": [
                 "Affinity",
                 "Spell"
@@ -56212,6 +56644,7 @@
             "name": "Shadow Sorcerer Quirks",
             "type": "table",
             "value": {
+              "title": "Shadow Sorcerer Quirks",
               "headers": [
                 "d6",
                 "Quirk"
@@ -56332,7 +56765,7 @@
           {
             "name": "",
             "type": "text",
-            "value": "The arcane magic you command is infused with elemental air. You can speak, read, and write Primordial. Knowing this language allows you to understand and be understood by those who speak its dialects: Primordial||Aquan, Primordial||Auran, Primordial||Ignan, and Primordial||Terran."
+            "value": "The arcane magic you command is infused with elemental air. You can speak, read, and write Primordial. Knowing this language allows you to understand and be understood by those who speak its dialects: Aquan, Auran, Ignan, and Terran."
           }
         ],
         "6": [
@@ -56413,6 +56846,7 @@
             "name": "Psionic Spells",
             "type": "table",
             "value": {
+              "title": "Psionic Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -56536,6 +56970,7 @@
             "name": "Clockwork Spells",
             "type": "table",
             "value": {
+              "title": "Clockwork Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -56564,6 +56999,7 @@
             "name": "Manifestations of Order",
             "type": "table",
             "value": {
+              "title": "Manifestations of Order",
               "headers": [
                 "1d6",
                 "Manifestation"
@@ -56685,6 +57121,7 @@
             "name": "Draconic Spells",
             "type": "table",
             "value": {
+              "title": "Draconic Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -56803,6 +57240,7 @@
             "name": "Wild Magic Surge",
             "type": "table",
             "value": {
+              "title": "Wild Magic Surge",
               "headers": [
                 "1d100",
                 "Effect"
@@ -56971,6 +57409,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57013,6 +57452,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57055,6 +57495,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57097,6 +57538,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57139,6 +57581,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57181,6 +57624,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57223,6 +57667,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57265,6 +57710,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57307,6 +57753,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57349,6 +57796,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57391,6 +57839,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57433,6 +57882,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57475,6 +57925,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57517,6 +57968,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57559,6 +58011,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57601,6 +58054,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57643,6 +58097,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57685,6 +58140,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57727,6 +58183,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57769,6 +58226,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -57955,6 +58413,7 @@
           "name": "Creating Spell Slots",
           "type": "table",
           "value": {
+            "title": "Creating Spell Slots",
             "headers": [
               "Spell Slot Level",
               "Sorcery Point Cost"
@@ -58042,6 +58501,7 @@
           "name": "Creating Spell Slots",
           "type": "table",
           "value": {
+            "title": "Creating Spell Slots",
             "headers": [
               "Spell Slot Level",
               "Sorcery Point Cost",
@@ -58403,6 +58863,7 @@
             "name": "Lunar Spells",
             "type": "table",
             "value": {
+              "title": "Lunar Spells",
               "headers": [
                 "Sorcerer Level",
                 "Full Moon Spell",
@@ -58572,6 +59033,7 @@
             "name": "Draconic Ancestry",
             "type": "table",
             "value": {
+              "title": "Draconic Ancestry",
               "headers": [
                 "Dragon",
                 "Damage Type"
@@ -58689,6 +59151,7 @@
             "name": "Wild Magic Surge",
             "type": "table",
             "value": {
+              "title": "Wild Magic Surge",
               "headers": [
                 "d100",
                 "Effect"
@@ -58986,6 +59449,7 @@
             "name": "Aberrant Origins",
             "type": "table",
             "value": {
+              "title": "Aberrant Origins",
               "headers": [
                 "d6",
                 "Origin"
@@ -59037,6 +59501,7 @@
             "name": "Psionic Spells",
             "type": "table",
             "value": {
+              "title": "Psionic Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -59184,6 +59649,7 @@
             "name": "Clockwork Spells",
             "type": "table",
             "value": {
+              "title": "Clockwork Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -59216,6 +59682,7 @@
             "name": "Manifestations of Order",
             "type": "table",
             "value": {
+              "title": "Manifestations of Order",
               "headers": [
                 "d6",
                 "Manifestation"
@@ -59392,6 +59859,7 @@
             "name": "Runic Spells",
             "type": "table",
             "value": {
+              "title": "Runic Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -59534,6 +60002,7 @@
             "name": "",
             "type": "table",
             "value": {
+              "title": "",
               "headers": [
                 "Affinity",
                 "Spell"
@@ -59626,6 +60095,7 @@
             "name": "Shadow Sorcerer Quirks",
             "type": "table",
             "value": {
+              "title": "Shadow Sorcerer Quirks",
               "headers": [
                 "d6",
                 "Quirk"
@@ -59746,7 +60216,7 @@
           {
             "name": "",
             "type": "text",
-            "value": "The arcane magic you command is infused with elemental air. You can speak, read, and write Primordial. Knowing this language allows you to understand and be understood by those who speak its dialects: Primordial||Aquan, Primordial||Auran, Primordial||Ignan, and Primordial||Terran."
+            "value": "The arcane magic you command is infused with elemental air. You can speak, read, and write Primordial. Knowing this language allows you to understand and be understood by those who speak its dialects: Aquan, Auran, Ignan, and Terran."
           }
         ],
         "6": [
@@ -59827,6 +60297,7 @@
             "name": "Psionic Spells",
             "type": "table",
             "value": {
+              "title": "Psionic Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -59950,6 +60421,7 @@
             "name": "Clockwork Spells",
             "type": "table",
             "value": {
+              "title": "Clockwork Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -59978,6 +60450,7 @@
             "name": "Manifestations of Order",
             "type": "table",
             "value": {
+              "title": "Manifestations of Order",
               "headers": [
                 "1d6",
                 "Manifestation"
@@ -60099,6 +60572,7 @@
             "name": "Draconic Spells",
             "type": "table",
             "value": {
+              "title": "Draconic Spells",
               "headers": [
                 "Sorcerer Level",
                 "Spells"
@@ -60217,6 +60691,7 @@
             "name": "Wild Magic Surge",
             "type": "table",
             "value": {
+              "title": "Wild Magic Surge",
               "headers": [
                 "1d100",
                 "Effect"
@@ -61099,6 +61574,7 @@
             "name": "Archfey Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Archfey Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -61196,6 +61672,7 @@
             "name": "Fiend Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Fiend Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -61288,6 +61765,7 @@
             "name": "Great Old One Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Great Old One Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -61380,6 +61858,7 @@
             "name": "Undying Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Undying Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -61497,6 +61976,7 @@
             "name": "Fathomless Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Fathomless Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -61649,6 +62129,7 @@
             "name": "Genie Kind",
             "type": "table",
             "value": {
+              "title": "Genie Kind",
               "headers": [
                 "d4",
                 "Kind",
@@ -61692,6 +62173,7 @@
             "name": "Genie Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Genie Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Genie Spells",
@@ -61786,6 +62268,7 @@
             "name": "Genie's Vessel",
             "type": "table",
             "value": {
+              "title": "Genie's Vessel",
               "headers": [
                 "d6",
                 "Vessel"
@@ -61907,6 +62390,7 @@
             "name": "Undead Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Undead Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -62059,6 +62543,7 @@
             "name": "Celestial Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Celestial Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -62166,6 +62651,7 @@
             "name": "Hexblade Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Hexblade Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -62283,6 +62769,7 @@
             "name": "Archfey Spells",
             "type": "table",
             "value": {
+              "title": "Archfey Spells",
               "headers": [
                 "Warlock Level",
                 "Spells"
@@ -62401,6 +62888,7 @@
             "name": "Celestial Spells",
             "type": "table",
             "value": {
+              "title": "Celestial Spells",
               "headers": [
                 "Warlock Level",
                 "Spells"
@@ -62499,6 +62987,7 @@
             "name": "Fiend Spells",
             "type": "table",
             "value": {
+              "title": "Fiend Spells",
               "headers": [
                 "Warlock Level",
                 "Spells"
@@ -62602,6 +63091,7 @@
             "name": "Great Old One Spells",
             "type": "table",
             "value": {
+              "title": "Great Old One Spells",
               "headers": [
                 "Warlock Level",
                 "Spells"
@@ -63415,6 +63905,7 @@
             "name": "Archfey Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Archfey Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -63512,6 +64003,7 @@
             "name": "Fiend Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Fiend Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -63604,6 +64096,7 @@
             "name": "Great Old One Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Great Old One Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -63696,6 +64189,7 @@
             "name": "Undying Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Undying Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -63813,6 +64307,7 @@
             "name": "Fathomless Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Fathomless Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -63965,6 +64460,7 @@
             "name": "Genie Kind",
             "type": "table",
             "value": {
+              "title": "Genie Kind",
               "headers": [
                 "d4",
                 "Kind",
@@ -64008,6 +64504,7 @@
             "name": "Genie Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Genie Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Genie Spells",
@@ -64102,6 +64599,7 @@
             "name": "Genie's Vessel",
             "type": "table",
             "value": {
+              "title": "Genie's Vessel",
               "headers": [
                 "d6",
                 "Vessel"
@@ -64223,6 +64721,7 @@
             "name": "Undead Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Undead Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -64375,6 +64874,7 @@
             "name": "Celestial Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Celestial Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -64482,6 +64982,7 @@
             "name": "Hexblade Expanded Spells",
             "type": "table",
             "value": {
+              "title": "Hexblade Expanded Spells",
               "headers": [
                 "Spell Level",
                 "Spells"
@@ -64599,6 +65100,7 @@
             "name": "Archfey Spells",
             "type": "table",
             "value": {
+              "title": "Archfey Spells",
               "headers": [
                 "Warlock Level",
                 "Spells"
@@ -64717,6 +65219,7 @@
             "name": "Celestial Spells",
             "type": "table",
             "value": {
+              "title": "Celestial Spells",
               "headers": [
                 "Warlock Level",
                 "Spells"
@@ -64815,6 +65318,7 @@
             "name": "Fiend Spells",
             "type": "table",
             "value": {
+              "title": "Fiend Spells",
               "headers": [
                 "Warlock Level",
                 "Spells"
@@ -64918,6 +65422,7 @@
             "name": "Great Old One Spells",
             "type": "table",
             "value": {
+              "title": "Great Old One Spells",
               "headers": [
                 "Warlock Level",
                 "Spells"
@@ -65022,6 +65527,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65064,6 +65570,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65106,6 +65613,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65148,6 +65656,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65190,6 +65699,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65232,6 +65742,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65274,6 +65785,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65316,6 +65828,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65358,6 +65871,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65400,6 +65914,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65442,6 +65957,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65484,6 +66000,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65526,6 +66043,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65568,6 +66086,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65610,6 +66129,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65652,6 +66172,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65694,6 +66215,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65736,6 +66258,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65778,6 +66301,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65820,6 +66344,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -65878,7 +66403,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*The spells that you add to your spellbook as you gain levels reflect the arcane research you conduct on your own, as well as intellectual breakthroughs you have had about the nature of the multiverse. You might find other spells during your adventures. You could discover a spell recorded on a scroll in an evil wizard's chest, for example, or in a dusty tome in an ancient library.\n\nA spellbook doesn't contain cantrips.\n\n**Copying a Spell into the Book**: When you find a wizard spell of 1st level or higher, you can add it to your spellbook if it is of a spell level you can prepare and if you can spare the time to decipher and copy it.\nCopying a spell into your spellbook involves reproducing the basic form of the spell, then deciphering the unique system of notation used by the wizard who wrote it. You must practice the spell until you understand the sounds or gestures required, then transcribe it into your spellbook using your own notation.\nFor each level of the spell, the process takes 2 hours and costs 50 gp. The cost represents material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it. Once you have spent this time and money, you can prepare the spell just like your other spells.\n**Copying from a Spell Scroll**: A wizard spell on a spell scroll can be copied just as spells in spellbooks can be copied. When you copy a spell from a spell scroll, you must succeed on an Intelligence (*Arcana*) check with a DC equal to 10 + the spell's level. If the check succeeds, the spell is successfully copied. Whether the check succeeds or fails, the spell scroll is destroyed.\n\n**Replacing the Book**: You can copy a spell from your own spellbook into another book—for example, if you want to make a backup copy of your spellbook. This is just like copying a new spell into your spellbook, but faster and easier, since you understand your own notation and already know how to cast the spell. You need spend only 1 hour and 10 gp for each level of the copied spell.\nIf you lose your spellbook, you can use the same procedure to transcribe the spells that you have prepared into a new spellbook. Filling out the remainder of your spellbook requires you to find new spells to do so, as normal. For this reason, many wizards keep backup spellbooks in a safe place.\n\n**The Book's Appearance**: Your spellbook is a unique compilation of spells, with its own decorative flourishes and margin notes. It might be a plain, functional leather volume that you received as a gift from your master, a finely bound gilt-edged tome you found in an ancient library, or even a loose collection of notes scrounged together after you lost your previous spellbook in a mishap.*"
+          "value": "*The spells that you add to your spellbook as you gain levels reflect the arcane research you conduct on your own, as well as intellectual breakthroughs you have had about the nature of the multiverse. You might find other spells during your adventures. You could discover a spell recorded on a scroll in an evil wizard's chest, for example, or in a dusty tome in an ancient library.*\n*A spellbook doesn't contain cantrips.*\n***Copying a Spell into the Book**: When you find a wizard spell of 1st level or higher, you can add it to your spellbook if it is of a spell level you can prepare and if you can spare the time to decipher and copy it.\nCopying a spell into your spellbook involves reproducing the basic form of the spell, then deciphering the unique system of notation used by the wizard who wrote it. You must practice the spell until you understand the sounds or gestures required, then transcribe it into your spellbook using your own notation.\nFor each level of the spell, the process takes 2 hours and costs 50 gp. The cost represents material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it. Once you have spent this time and money, you can prepare the spell just like your other spells.\n**Copying from a Spell Scroll**: A wizard spell on a spell scroll can be copied just as spells in spellbooks can be copied. When you copy a spell from a spell scroll, you must succeed on an Intelligence (*Arcana*) check with a DC equal to 10 + the spell's level. If the check succeeds, the spell is successfully copied. Whether the check succeeds or fails, the spell scroll is destroyed.*\n***Replacing the Book**: You can copy a spell from your own spellbook into another book—for example, if you want to make a backup copy of your spellbook. This is just like copying a new spell into your spellbook, but faster and easier, since you understand your own notation and already know how to cast the spell. You need spend only 1 hour and 10 gp for each level of the copied spell.\nIf you lose your spellbook, you can use the same procedure to transcribe the spells that you have prepared into a new spellbook. Filling out the remainder of your spellbook requires you to find new spells to do so, as normal. For this reason, many wizards keep backup spellbooks in a safe place.*\n***The Book's Appearance**: Your spellbook is a unique compilation of spells, with its own decorative flourishes and margin notes. It might be a plain, functional leather volume that you received as a gift from your master, a finely bound gilt-edged tome you found in an ancient library, or even a loose collection of notes scrounged together after you lost your previous spellbook in a mishap.*"
         },
         {
           "name": "Cantrips",
@@ -65963,7 +66488,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*The spells you add to your spellbook as you gain levels reflect your ongoing magical research, but you might find other spells during your adventures that you can add to the book. You could discover a Wizard spell on a Spell Scroll, for example, and then copy it into your spellbook.\n\n**Copying a Spell into the Book**: When you find a level 1+ Wizard spell, you can copy it into your spellbook if it's of a level you can prepare and if you have time to copy it. For each level of the spell, the transcription takes 2 hours and costs 50 GP. Afterward you can prepare the spell like the other spells in your spellbook.\n\n**Copying the Book**: You can copy a spell from your spellbook into another book. This is like copying a new spell into your spellbook but faster, since you already know how to cast the spell. You need spend only 1 hour and 10 GP for each level of the copied spell.\nIf you lose your spellbook, you can use the same procedure to transcribe the Wizard spells that you have prepared into a new spellbook. Filling out the remainder of the new book requires you to find new spells to do so. For this reason, many wizards keep a backup spellbook.*"
+          "value": "*The spells you add to your spellbook as you gain levels reflect your ongoing magical research, but you might find other spells during your adventures that you can add to the book. You could discover a Wizard spell on a Spell Scroll, for example, and then copy it into your spellbook.*\n***Copying a Spell into the Book**: When you find a level 1+ Wizard spell, you can copy it into your spellbook if it's of a level you can prepare and if you have time to copy it. For each level of the spell, the transcription takes 2 hours and costs 50 GP. Afterward you can prepare the spell like the other spells in your spellbook.*\n***Copying the Book**: You can copy a spell from your spellbook into another book. This is like copying a new spell into your spellbook but faster, since you already know how to cast the spell. You need spend only 1 hour and 10 GP for each level of the copied spell.\nIf you lose your spellbook, you can use the same procedure to transcribe the Wizard spells that you have prepared into a new spellbook. Filling out the remainder of the new book requires you to find new spells to do so. For this reason, many wizards keep a backup spellbook.*"
         },
         {
           "name": "Cantrips",
@@ -67696,6 +68221,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -67738,6 +68264,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -67780,6 +68307,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -67822,6 +68350,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -67864,6 +68393,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -67906,6 +68436,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -67948,6 +68479,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -67990,6 +68522,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68032,6 +68565,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68074,6 +68608,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68116,6 +68651,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68158,6 +68694,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68200,6 +68737,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68242,6 +68780,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68284,6 +68823,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68326,6 +68866,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68368,6 +68909,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68410,6 +68952,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68452,6 +68995,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68494,6 +69038,7 @@
           "name": "Spell Slots per Spell Level",
           "type": "table",
           "value": {
+            "title": "Spell Slots per Spell Level",
             "headers": [
               "1st",
               "2nd",
@@ -68552,7 +69097,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*The spells that you add to your spellbook as you gain levels reflect the arcane research you conduct on your own, as well as intellectual breakthroughs you have had about the nature of the multiverse. You might find other spells during your adventures. You could discover a spell recorded on a scroll in an evil wizard's chest, for example, or in a dusty tome in an ancient library.\n\nA spellbook doesn't contain cantrips.\n\n**Copying a Spell into the Book**: When you find a wizard spell of 1st level or higher, you can add it to your spellbook if it is of a spell level you can prepare and if you can spare the time to decipher and copy it.\nCopying a spell into your spellbook involves reproducing the basic form of the spell, then deciphering the unique system of notation used by the wizard who wrote it. You must practice the spell until you understand the sounds or gestures required, then transcribe it into your spellbook using your own notation.\nFor each level of the spell, the process takes 2 hours and costs 50 gp. The cost represents material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it. Once you have spent this time and money, you can prepare the spell just like your other spells.\n**Copying from a Spell Scroll**: A wizard spell on a spell scroll can be copied just as spells in spellbooks can be copied. When you copy a spell from a spell scroll, you must succeed on an Intelligence (*Arcana*) check with a DC equal to 10 + the spell's level. If the check succeeds, the spell is successfully copied. Whether the check succeeds or fails, the spell scroll is destroyed.\n\n**Replacing the Book**: You can copy a spell from your own spellbook into another book—for example, if you want to make a backup copy of your spellbook. This is just like copying a new spell into your spellbook, but faster and easier, since you understand your own notation and already know how to cast the spell. You need spend only 1 hour and 10 gp for each level of the copied spell.\nIf you lose your spellbook, you can use the same procedure to transcribe the spells that you have prepared into a new spellbook. Filling out the remainder of your spellbook requires you to find new spells to do so, as normal. For this reason, many wizards keep backup spellbooks in a safe place.\n\n**The Book's Appearance**: Your spellbook is a unique compilation of spells, with its own decorative flourishes and margin notes. It might be a plain, functional leather volume that you received as a gift from your master, a finely bound gilt-edged tome you found in an ancient library, or even a loose collection of notes scrounged together after you lost your previous spellbook in a mishap.*"
+          "value": "*The spells that you add to your spellbook as you gain levels reflect the arcane research you conduct on your own, as well as intellectual breakthroughs you have had about the nature of the multiverse. You might find other spells during your adventures. You could discover a spell recorded on a scroll in an evil wizard's chest, for example, or in a dusty tome in an ancient library.*\n*A spellbook doesn't contain cantrips.*\n***Copying a Spell into the Book**: When you find a wizard spell of 1st level or higher, you can add it to your spellbook if it is of a spell level you can prepare and if you can spare the time to decipher and copy it.\nCopying a spell into your spellbook involves reproducing the basic form of the spell, then deciphering the unique system of notation used by the wizard who wrote it. You must practice the spell until you understand the sounds or gestures required, then transcribe it into your spellbook using your own notation.\nFor each level of the spell, the process takes 2 hours and costs 50 gp. The cost represents material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it. Once you have spent this time and money, you can prepare the spell just like your other spells.\n**Copying from a Spell Scroll**: A wizard spell on a spell scroll can be copied just as spells in spellbooks can be copied. When you copy a spell from a spell scroll, you must succeed on an Intelligence (*Arcana*) check with a DC equal to 10 + the spell's level. If the check succeeds, the spell is successfully copied. Whether the check succeeds or fails, the spell scroll is destroyed.*\n***Replacing the Book**: You can copy a spell from your own spellbook into another book—for example, if you want to make a backup copy of your spellbook. This is just like copying a new spell into your spellbook, but faster and easier, since you understand your own notation and already know how to cast the spell. You need spend only 1 hour and 10 gp for each level of the copied spell.\nIf you lose your spellbook, you can use the same procedure to transcribe the spells that you have prepared into a new spellbook. Filling out the remainder of your spellbook requires you to find new spells to do so, as normal. For this reason, many wizards keep backup spellbooks in a safe place.*\n***The Book's Appearance**: Your spellbook is a unique compilation of spells, with its own decorative flourishes and margin notes. It might be a plain, functional leather volume that you received as a gift from your master, a finely bound gilt-edged tome you found in an ancient library, or even a loose collection of notes scrounged together after you lost your previous spellbook in a mishap.*"
         },
         {
           "name": "Cantrips",
@@ -68637,7 +69182,7 @@
         {
           "name": "",
           "type": "text",
-          "value": "*The spells you add to your spellbook as you gain levels reflect your ongoing magical research, but you might find other spells during your adventures that you can add to the book. You could discover a Wizard spell on a Spell Scroll, for example, and then copy it into your spellbook.\n\n**Copying a Spell into the Book**: When you find a level 1+ Wizard spell, you can copy it into your spellbook if it's of a level you can prepare and if you have time to copy it. For each level of the spell, the transcription takes 2 hours and costs 50 GP. Afterward you can prepare the spell like the other spells in your spellbook.\n\n**Copying the Book**: You can copy a spell from your spellbook into another book. This is like copying a new spell into your spellbook but faster, since you already know how to cast the spell. You need spend only 1 hour and 10 GP for each level of the copied spell.\nIf you lose your spellbook, you can use the same procedure to transcribe the Wizard spells that you have prepared into a new spellbook. Filling out the remainder of the new book requires you to find new spells to do so. For this reason, many wizards keep a backup spellbook.*"
+          "value": "*The spells you add to your spellbook as you gain levels reflect your ongoing magical research, but you might find other spells during your adventures that you can add to the book. You could discover a Wizard spell on a Spell Scroll, for example, and then copy it into your spellbook.*\n***Copying a Spell into the Book**: When you find a level 1+ Wizard spell, you can copy it into your spellbook if it's of a level you can prepare and if you have time to copy it. For each level of the spell, the transcription takes 2 hours and costs 50 GP. Afterward you can prepare the spell like the other spells in your spellbook.*\n***Copying the Book**: You can copy a spell from your spellbook into another book. This is like copying a new spell into your spellbook but faster, since you already know how to cast the spell. You need spend only 1 hour and 10 GP for each level of the copied spell.\nIf you lose your spellbook, you can use the same procedure to transcribe the Wizard spells that you have prepared into a new spellbook. Filling out the remainder of the new book requires you to find new spells to do so. For this reason, many wizards keep a backup spellbook.*"
         },
         {
           "name": "Cantrips",

--- a/generated/conditions.json
+++ b/generated/conditions.json
@@ -136,6 +136,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Level",
             "Effect"

--- a/generated/feats.json
+++ b/generated/feats.json
@@ -31,6 +31,7 @@
         "name": "Aberrant Dragonmark Flaws",
         "type": "table",
         "value": {
+          "title": "Aberrant Dragonmark Flaws",
           "headers": [
             "d8",
             "Flaw"
@@ -864,7 +865,36 @@
       {
         "name": "",
         "type": "text",
-        "value": "• **Chaotic Flare**: When you roll a 1 or a 20 on an attack roll or a saving throw, the magic of chaos flows through you. Roll a d4 and consult the Chaotic Flares table to determine what happens. A flare lasts until the end of your next turn, and a new flare can't occur until after the first flare ends.\n[object Object]"
+        "value": "• **Chaotic Flare**: When you roll a 1 or a 20 on an attack roll or a saving throw, the magic of chaos flows through you. Roll a d4 and consult the Chaotic Flares table to determine what happens. A flare lasts until the end of your next turn, and a new flare can't occur until after the first flare ends."
+      },
+      {
+        "name": "Chaotic Flares",
+        "type": "table",
+        "value": {
+          "title": "Chaotic Flares",
+          "headers": [
+            "d4",
+            "Flare"
+          ],
+          "rows": [
+            [
+              "1",
+              "Battle Fury. A creature of your choice that you can see is filled with reckless fury. It has advantage on attack rolls and disadvantage on ability checks."
+            ],
+            [
+              "2",
+              "Disruption Field. Waves of energy ripple around you. Every creature that starts its turn within 5 feet of you, or that moves into that area for the first time on a turn, takes 1d8 force damage."
+            ],
+            [
+              "3",
+              "Unbound. When you move, you can use some or all of your walking speed to teleport yourself once, along with any equipment you're wearing or carrying, up to the distance used to an unoccupied space that you can see."
+            ],
+            [
+              "4",
+              "Wailing Winds. Winds swirl in a 15-foot-radius sphere centered on you. You and any other creatures in that area have disadvantage on Wisdom saving throws."
+            ]
+          ]
+        }
       }
     ]
   },
@@ -900,6 +930,7 @@
         "name": "Fast Crafting",
         "type": "table",
         "value": {
+          "title": "Fast Crafting",
           "headers": [
             "Artisan's Tools",
             "Crafted Gear"
@@ -1154,6 +1185,7 @@
         "name": "Alignment Spells",
         "type": "table",
         "value": {
+          "title": "Alignment Spells",
           "headers": [
             "Alignment",
             "1st-Level Spell"
@@ -1647,7 +1679,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "*The Flash Recall feat requires you to be a spellcaster who prepares spells. This includes classes such as __cleric||clerics__, __druid||druids__, and __paladin||paladins__, who prepare spells each day from their class list, and __wizard||wizards__, who prepare spells from a spellbook. Classes such as __bard||bards__ and __sorcerer||sorcerers__, who inherently know their spells rather than preparing them, can't benefit from this feat.*"
+        "value": "*The Flash Recall feat requires you to be a spellcaster who prepares spells. This includes classes such as __clerics__, __druids__, and __paladins__, who prepare spells each day from their class list, and __wizards__, who prepare spells from a spellbook. Classes such as __bards__ and __sorcerers__, who inherently know their spells rather than preparing them, can't benefit from this feat.*"
       }
     ]
   },
@@ -2058,6 +2090,7 @@
         "name": "Lunar Spells",
         "type": "table",
         "value": {
+          "title": "Lunar Spells",
           "headers": [
             "Moon",
             "1st-Level Spell"
@@ -3241,7 +3274,72 @@
       {
         "name": "",
         "type": "text",
-        "value": "• **Comprehend Languages**: You learn the __comprehend languages__ spell. You can cast this spell without expending a spell slot, and you must finish a long rest before you can cast it in this way again. You can also cast this spell using any spell slots you have.\n• **Rune Magic**: You know a number of runes equal to half your proficiency bonus (rounded down), chosen from the Rune Spells table. Whenever you finish a long rest, you can inscribe each rune you know onto one nonmagical weapon, armor, piece of clothing, or other object you touch. You temporarily learn the 1st-level spells that correspond to the runes you inscribed, as specified on the Rune Spells table, and you know those spells until you finish a long rest, when the runes fade. While you are wearing or carrying any rune-marked object, you can cast the spells associated with those runes using any spell slots you have.\nYou can also invoke a rune inscribed on an object you are wearing or carrying and cast its associated spell without expending a spell slot or using material components. Once you cast the spell in this way, you can't do so again until you finish a long rest. Your spellcasting ability for this feat is Intelligence, Wisdom, or Charisma (choose when you select this feat).\nEach time you gain a level, you can replace one of the runes you know with another one from the Rune Spells table.\n[object Object]"
+        "value": "• **Comprehend Languages**: You learn the __comprehend languages__ spell. You can cast this spell without expending a spell slot, and you must finish a long rest before you can cast it in this way again. You can also cast this spell using any spell slots you have.\n• **Rune Magic**: You know a number of runes equal to half your proficiency bonus (rounded down), chosen from the Rune Spells table. Whenever you finish a long rest, you can inscribe each rune you know onto one nonmagical weapon, armor, piece of clothing, or other object you touch. You temporarily learn the 1st-level spells that correspond to the runes you inscribed, as specified on the Rune Spells table, and you know those spells until you finish a long rest, when the runes fade. While you are wearing or carrying any rune-marked object, you can cast the spells associated with those runes using any spell slots you have.\nYou can also invoke a rune inscribed on an object you are wearing or carrying and cast its associated spell without expending a spell slot or using material components. Once you cast the spell in this way, you can't do so again until you finish a long rest. Your spellcasting ability for this feat is Intelligence, Wisdom, or Charisma (choose when you select this feat).\nEach time you gain a level, you can replace one of the runes you know with another one from the Rune Spells table."
+      },
+      {
+        "name": "",
+        "type": "table",
+        "value": {
+          "title": "",
+          "headers": [
+            "Rune",
+            "Spell"
+          ],
+          "rows": [
+            [
+              "Cloud",
+              "Fog cloud"
+            ],
+            [
+              "Death",
+              "Inflict wounds"
+            ],
+            [
+              "Dragon",
+              "Chromatic orb"
+            ],
+            [
+              "Enemy",
+              "Disguise self"
+            ],
+            [
+              "Fire",
+              "Burning hands"
+            ],
+            [
+              "Friend",
+              "Speak with animals"
+            ],
+            [
+              "Frost",
+              "Armor of Agathys"
+            ],
+            [
+              "Hill",
+              "Goodberry"
+            ],
+            [
+              "Journey",
+              "Longstrider"
+            ],
+            [
+              "King",
+              "Command"
+            ],
+            [
+              "Mountain",
+              "Entangle"
+            ],
+            [
+              "Stone",
+              "Sanctuary"
+            ],
+            [
+              "Storm",
+              "Thunderwave"
+            ]
+          ]
+        }
       }
     ]
   },
@@ -3292,6 +3390,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Plane",
             "Damage Resistance",
@@ -3985,6 +4084,7 @@
         "name": "Strixhaven Spells",
         "type": "table",
         "value": {
+          "title": "Strixhaven Spells",
           "headers": [
             "College",
             "Cantrips",

--- a/generated/items.json
+++ b/generated/items.json
@@ -1316,6 +1316,7 @@
         "name": "Trinkets from Aerenal",
         "type": "table",
         "value": {
+          "title": "Trinkets from Aerenal",
           "headers": [
             "d8",
             "Trinket"
@@ -1637,6 +1638,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Liquid",
             "Max Amount"
@@ -1718,6 +1720,7 @@
         "name": "Alchemy Jug Liquids",
         "type": "table",
         "value": {
+          "title": "Alchemy Jug Liquids",
           "headers": [
             "Liquid",
             "Max. Amount"
@@ -1799,6 +1802,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Liquid",
             "Max Amount"
@@ -1876,6 +1880,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Liquid",
             "Max Amount"
@@ -2434,6 +2439,7 @@
         "name": "Black Skull Transformation",
         "type": "table",
         "value": {
+          "title": "Black Skull Transformation",
           "headers": [
             "d100",
             "Transformation"
@@ -2581,6 +2587,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d100",
             "Destination"
@@ -2765,6 +2772,7 @@
         "name": "Apparatus of Kwalish Levers:",
         "type": "table",
         "value": {
+          "title": "Apparatus of Kwalish Levers:",
           "headers": [
             "Lever",
             "Up",
@@ -2867,6 +2875,7 @@
         "name": "Apparatus of Kwalish Levers",
         "type": "table",
         "value": {
+          "title": "Apparatus of Kwalish Levers",
           "headers": [
             "Lever",
             "Up",
@@ -3190,6 +3199,7 @@
         "name": "Trinkets from Argonnessen",
         "type": "table",
         "value": {
+          "title": "Trinkets from Argonnessen",
           "headers": [
             "d10",
             "Trinket"
@@ -4235,6 +4245,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d100",
             "Effect"
@@ -4324,6 +4335,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d100",
             "Effect"
@@ -4544,6 +4556,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d8",
             "Creature"
@@ -4622,6 +4635,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d8",
             "Creature"
@@ -4700,6 +4714,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d8",
             "Creature"
@@ -4778,6 +4793,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d8",
             "Creature"
@@ -4856,6 +4872,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d8",
             "Creature"
@@ -4934,6 +4951,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d8",
             "Creature"
@@ -5307,6 +5325,7 @@
         "name": "Barrier Peaks Trinkets",
         "type": "table",
         "value": {
+          "title": "Barrier Peaks Trinkets",
           "headers": [
             "d100",
             "Trinket"
@@ -5644,6 +5663,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d10",
             "Catch"
@@ -7109,6 +7129,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Distance from Origin",
             "Effect"
@@ -7568,6 +7589,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d6",
             "Lycanthropy"
@@ -10289,6 +10311,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d20",
             "Alignment"
@@ -10366,6 +10389,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d100",
             "Outer Plane"
@@ -11152,6 +11176,7 @@
         "name": "Possible Map Mission Landmarks",
         "type": "table",
         "value": {
+          "title": "Possible Map Mission Landmarks",
           "headers": [
             "d8",
             "Landmark"
@@ -11397,6 +11422,7 @@
         "name": "Cataclysm Bolt Effects",
         "type": "table",
         "value": {
+          "title": "Cataclysm Bolt Effects",
           "headers": [
             "d6",
             "Effect"
@@ -13280,6 +13306,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d4",
             "Decision"
@@ -14302,6 +14329,7 @@
         "name": "Extraplanar Reversal",
         "type": "table",
         "value": {
+          "title": "Extraplanar Reversal",
           "headers": [
             "d100",
             "Effect"
@@ -14892,6 +14920,7 @@
         "name": "Cube of Force Faces",
         "type": "table",
         "value": {
+          "title": "Cube of Force Faces",
           "headers": [
             "Face",
             "Charges",
@@ -14935,6 +14964,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell or item",
             "Charges Lost"
@@ -14991,6 +15021,7 @@
         "name": "Cube of Force Faces",
         "type": "table",
         "value": {
+          "title": "Cube of Force Faces",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -15056,6 +15087,7 @@
         "name": "Cube of Summoning",
         "type": "table",
         "value": {
+          "title": "Cube of Summoning",
           "headers": [
             "1d6",
             "Spell"
@@ -15637,6 +15669,7 @@
         "name": "Lenses",
         "type": "table",
         "value": {
+          "title": "Lenses",
           "headers": [
             "Lens Color",
             "Spell",
@@ -15970,6 +16003,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d34 (Playing Card)",
             "Illusion"
@@ -16143,6 +16177,7 @@
         "name": "Deck of Illusions",
         "type": "table",
         "value": {
+          "title": "Deck of Illusions",
           "headers": [
             "1d100",
             "Illusion"
@@ -16331,6 +16366,7 @@
         "name": "Deck of Many More Things",
         "type": "table",
         "value": {
+          "title": "Deck of Many More Things",
           "headers": [
             "d100",
             "Card"
@@ -16914,6 +16950,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d22 (Playing Card)",
             "Card"
@@ -17157,12 +17194,13 @@
       {
         "name": "",
         "type": "text",
-        "value": "*Two of the cards in the Deck of Many Things can earn a character the enmity of another being. With the Flames card, the enmity is overt. The character should experience the devil's malevolent efforts on multiple occasions. Seeking out the fiend shouldn't be a simple task, and the adventurer should clash with the devil's allies and followers a few times before being able to confront the devil.\n\nIn the case of the Rogue card, the enmity is secret and should come from someone thought to be a friend or an ally. As Dungeon Master, you should wait for a dramatically appropriate moment to reveal this enmity, leaving the adventurer guessing who is likely to become a betrayer.*"
+        "value": "*Two of the cards in the Deck of Many Things can earn a character the enmity of another being. With the Flames card, the enmity is overt. The character should experience the devil's malevolent efforts on multiple occasions. Seeking out the fiend shouldn't be a simple task, and the adventurer should clash with the devil's allies and followers a few times before being able to confront the devil.*\n*In the case of the Rogue card, the enmity is secret and should come from someone thought to be a friend or an ally. As Dungeon Master, you should wait for a dramatically appropriate moment to reveal this enmity, leaving the adventurer guessing who is likely to become a betrayer.*"
       },
       {
         "name": "Deck of Many Things",
         "type": "table",
         "value": {
+          "title": "Deck of Many Things",
           "headers": [
             "1d100 (13-Card Deck)",
             "1d100 (22-Card Deck)",
@@ -17420,6 +17458,7 @@
         "name": "Deck of Miscellany",
         "type": "table",
         "value": {
+          "title": "Deck of Miscellany",
           "headers": [
             "1d32 (Card)",
             "Item"
@@ -17607,12 +17646,13 @@
       {
         "name": "",
         "type": "text",
-        "value": "*The special nature of this deck (carried by __Mary Greymalkin__ if she is used as an NPC) means that many of its effects operate only within and with respect to this specific adventure. This typically covers any time the characters spend between setting out for the Barrier Peaks and the resolution of whatever events transpire in Kwalish's lab (area O7).\n\nFor cards that effectively remove a character from play for a period of time (Donjon and the Void), you can allow a player to take on the role of one of the party's NPC hirelings, or introduce a temporary character as an NPC met during the party's journey. Alternatively, you can decide that only some aspect of the character's will disappears and is imprisoned, leaving the character to operate in a robotic state until freed.*"
+        "value": "*The special nature of this deck (carried by __Mary Greymalkin__ if she is used as an NPC) means that many of its effects operate only within and with respect to this specific adventure. This typically covers any time the characters spend between setting out for the Barrier Peaks and the resolution of whatever events transpire in Kwalish's lab (area O7).*\n*For cards that effectively remove a character from play for a period of time (Donjon and the Void), you can allow a player to take on the role of one of the party's NPC hirelings, or introduce a temporary character as an NPC met during the party's journey. Alternatively, you can decide that only some aspect of the character's will disappears and is imprisoned, leaving the character to operate in a robotic state until freed.*"
       },
       {
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d22 (Playing Card)",
             "Card"
@@ -17847,6 +17887,7 @@
         "name": "Deck of Wild Cards",
         "type": "table",
         "value": {
+          "title": "Deck of Wild Cards",
           "headers": [
             "d4",
             "Suit",
@@ -17914,6 +17955,7 @@
         "name": "Deck of Wonder",
         "type": "table",
         "value": {
+          "title": "Deck of Wonder",
           "headers": [
             "1d22 (Card)",
             "Card Title"
@@ -18419,6 +18461,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -19130,6 +19173,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d12",
             "effect"
@@ -20631,6 +20675,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d100",
             "Effect"
@@ -20679,6 +20724,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d10",
             "Effect"
@@ -20924,6 +20970,7 @@
         "name": "Elemental Essence Shards",
         "type": "table",
         "value": {
+          "title": "Elemental Essence Shards",
           "headers": [
             "d4",
             "Element",
@@ -21359,6 +21406,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d8",
             "Trinket"
@@ -22594,7 +22642,40 @@
       {
         "name": "",
         "type": "text",
-        "value": "• **Truesight**: You have Truesight out to 240 feet.\n• **Spellcasting**: The eye has 8 charges and regains 1d4 + 4 expended charges daily at dawn. You can cast a spell on the Eye of Vecna Spells table from the eye (save DC 18). The table indicates how many charges you must expend to cast the spell. Each time you cast a spell from the eye, there is a 5 percent chance that Vecna tears your soul from your body, devours it, and then takes control of the body like a puppet. If that happens, you become an NPC under the DM's control.\n[object Object]\n• **X-ray Vision**: You can take a Magic action to gain X-ray vision with a range of 30 feet for 1 minute. To you, solid objects within that radius appear transparent and don't prevent light from passing through themselves. The vision can penetrate 1 foot of stone, 1 inch of common metal, or up to 3 feet of wood or dirt. Thicker substances block the vision, as does a thin sheet of lead."
+        "value": "• **Truesight**: You have Truesight out to 240 feet.\n• **Spellcasting**: The eye has 8 charges and regains 1d4 + 4 expended charges daily at dawn. You can cast a spell on the Eye of Vecna Spells table from the eye (save DC 18). The table indicates how many charges you must expend to cast the spell. Each time you cast a spell from the eye, there is a 5 percent chance that Vecna tears your soul from your body, devours it, and then takes control of the body like a puppet. If that happens, you become an NPC under the DM's control.\n• **X-ray Vision**: You can take a Magic action to gain X-ray vision with a range of 30 feet for 1 minute. To you, solid objects within that radius appear transparent and don't prevent light from passing through themselves. The vision can penetrate 1 foot of stone, 1 inch of common metal, or up to 3 feet of wood or dirt. Thicker substances block the vision, as does a thin sheet of lead."
+      },
+      {
+        "name": "Eye of Vecna Spells",
+        "type": "table",
+        "value": {
+          "title": "Eye of Vecna Spells",
+          "headers": [
+            "Spell",
+            "Charge Cost"
+          ],
+          "rows": [
+            [
+              "Clairvoyance",
+              "2"
+            ],
+            [
+              "Crown of Madness",
+              "1"
+            ],
+            [
+              "Disintegrate",
+              "4"
+            ],
+            [
+              "Dominate Monster",
+              "5"
+            ],
+            [
+              "Eyebite",
+              "4"
+            ]
+          ]
+        }
       },
       {
         "name": "Destroying the Eye and Hand",
@@ -22844,6 +22925,7 @@
         "name": "Faerie Dust",
         "type": "table",
         "value": {
+          "title": "Faerie Dust",
           "headers": [
             "d100",
             "Magical Effect"
@@ -23298,6 +23380,7 @@
         "name": "Feywild Trinkets",
         "type": "table",
         "value": {
+          "title": "Feywild Trinkets",
           "headers": [
             "d100",
             "Trinket"
@@ -25045,7 +25128,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "*Chariots and the creatures pulling them work like controlled mounts, as described in the mounted combat rules in the Player's Handbook, but with the following differences:\n\n• Mounting or dismounting a chariot costs you 5 feet of movement, rather than a number of feet equal to half your speed.\n• Being mounted on a chariot grants you Cover.\n• A chariot's speed is equal to the speed of the slowest creature pulling it.\n• If multiple creatures are pulling the chariot, they all act on the same initiative, and they must take the same action on their turn.*"
+        "value": "*Chariots and the creatures pulling them work like controlled mounts, as described in the mounted combat rules in the Player's Handbook, but with the following differences:*\n*• Mounting or dismounting a chariot costs you 5 feet of movement, rather than a number of feet equal to half your speed.\n• Being mounted on a chariot grants you Cover.\n• A chariot's speed is equal to the speed of the slowest creature pulling it.\n• If multiple creatures are pulling the chariot, they all act on the same initiative, and they must take the same action on their turn.*"
       }
     ],
     "properties": []
@@ -25346,6 +25429,7 @@
         "name": "Trinkets from the Frostfell and Everice",
         "type": "table",
         "value": {
+          "title": "Trinkets from the Frostfell and Everice",
           "headers": [
             "d8",
             "Trinket"
@@ -25583,6 +25667,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d6",
             "Trinket"
@@ -25955,6 +26040,7 @@
         "name": "Giant Trinkets",
         "type": "table",
         "value": {
+          "title": "Giant Trinkets",
           "headers": [
             "d6",
             "Giant Trinket"
@@ -27369,6 +27455,7 @@
         "name": "Goose Egg Trinket",
         "type": "table",
         "value": {
+          "title": "Goose Egg Trinket",
           "headers": [
             "d12",
             "Egg Contents"
@@ -28440,7 +28527,36 @@
       {
         "name": "",
         "type": "text",
-        "value": "• **Great Strength**: Your Strength becomes 20 unless it is already 20 or higher.\n• **Icy Touch**: Any melee spell attack you make with the hand and any melee attack made with a weapon held by it deals an extra **2d8** Cold damage on a hit.\n• **Spellcasting**: The hand has 8 charges and regains 1d4 + 4 expended charges daily at dawn. You can cast a spell on the Hand of Vecna Spells table from the hand (save DC 18). The table indicates how many charges you must expend to cast the spell. Each time you cast a spell from it, the hand casts __Suggestion__ on you (save DC 18; no *Concentration* required), demanding that you commit an evil act. The hand might have a specific act in mind or leave it up to you.\n[object Object]"
+        "value": "• **Great Strength**: Your Strength becomes 20 unless it is already 20 or higher.\n• **Icy Touch**: Any melee spell attack you make with the hand and any melee attack made with a weapon held by it deals an extra **2d8** Cold damage on a hit.\n• **Spellcasting**: The hand has 8 charges and regains 1d4 + 4 expended charges daily at dawn. You can cast a spell on the Hand of Vecna Spells table from the hand (save DC 18). The table indicates how many charges you must expend to cast the spell. Each time you cast a spell from it, the hand casts __Suggestion__ on you (save DC 18; no *Concentration* required), demanding that you commit an evil act. The hand might have a specific act in mind or leave it up to you."
+      },
+      {
+        "name": "Hand of Vecna Spells",
+        "type": "table",
+        "value": {
+          "title": "Hand of Vecna Spells",
+          "headers": [
+            "Spell",
+            "Charge Cost"
+          ],
+          "rows": [
+            [
+              "Finger of Death",
+              "5"
+            ],
+            [
+              "Sleep",
+              "1"
+            ],
+            [
+              "Slow",
+              "2"
+            ],
+            [
+              "Teleport",
+              "3"
+            ]
+          ]
+        }
       },
       {
         "name": "Destroying the Eye and Hand",
@@ -28652,6 +28768,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d100",
             "Effect"
@@ -29416,6 +29533,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "God",
             "Spell"
@@ -30168,6 +30286,7 @@
         "name": "Hook of Fisher's Delight",
         "type": "table",
         "value": {
+          "title": "Hook of Fisher's Delight",
           "headers": [
             "d20",
             "Fish Color",
@@ -30598,6 +30717,7 @@
         "name": "Horror Trinkets",
         "type": "table",
         "value": {
+          "title": "Horror Trinkets",
           "headers": [
             "d100",
             "Trinket"
@@ -31222,6 +31342,7 @@
         "name": "Icewind Dale Trinkets",
         "type": "table",
         "value": {
+          "title": "Icewind Dale Trinkets",
           "headers": [
             "d100",
             "Trinket"
@@ -31396,7 +31517,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "*As explained in the description of Iggwilv's Cauldron, the poem titled \"The Witch Queen's Cauldron\" is an incantation that hints at the time-freezing property of the artifact:\n\n*Eight cats perch atop eight dead attending\n\nEight lizards flee from eight rats scavenging\n\nEight toads climbing meet eight dead and falling\n\nEight snakes sneak under eight bats screaming\n\nEight eyes open, always dreaming\n\nAll on the cauldron that is ever seeming**"
+        "value": "*As explained in the description of Iggwilv's Cauldron, the poem titled \"The Witch Queen's Cauldron\" is an incantation that hints at the time-freezing property of the artifact:*\n**Eight cats perch atop eight dead attending\n\nEight lizards flee from eight rats scavenging\n\nEight toads climbing meet eight dead and falling\n\nEight snakes sneak under eight bats screaming\n\nEight eyes open, always dreaming\n\nAll on the cauldron that is ever seeming**"
       },
       {
         "name": "Attunement",
@@ -33889,6 +34010,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d100",
             "Contents"
@@ -34050,6 +34172,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d100",
             "Contents"
@@ -35557,6 +35680,7 @@
         "name": "Trinkets from Khyber",
         "type": "table",
         "value": {
+          "title": "Trinkets from Khyber",
           "headers": [
             "d10",
             "Trinket"
@@ -35998,6 +36122,7 @@
         "name": "Lantern of Tracking",
         "type": "table",
         "value": {
+          "title": "Lantern of Tracking",
           "headers": [
             "1d10",
             "Creature Type"
@@ -36677,6 +36802,7 @@
         "name": "Class-Based Living Loot Satchel",
         "type": "table",
         "value": {
+          "title": "Class-Based Living Loot Satchel",
           "headers": [
             "Class",
             "Satchel"
@@ -37167,6 +37293,7 @@
         "name": "Lorehold Trinkets",
         "type": "table",
         "value": {
+          "title": "Lorehold Trinkets",
           "headers": [
             "d6",
             "Trinket"
@@ -37301,6 +37428,7 @@
         "name": "Souls of the Tarokka",
         "type": "table",
         "value": {
+          "title": "Souls of the Tarokka",
           "headers": [
             "d100",
             "Card",
@@ -39720,6 +39848,7 @@
         "name": "Mirror Locations",
         "type": "table",
         "value": {
+          "title": "Mirror Locations",
           "headers": [
             "d8",
             "Location",
@@ -40002,6 +40131,7 @@
         "name": "1st-Level Spells",
         "type": "table",
         "value": {
+          "title": "1st-Level Spells",
           "headers": [
             "d6",
             "spell"
@@ -40038,6 +40168,7 @@
         "name": "2nd-Level Spells",
         "type": "table",
         "value": {
+          "title": "2nd-Level Spells",
           "headers": [
             "d6",
             "spell"
@@ -40074,6 +40205,7 @@
         "name": "3rd-Level Spells",
         "type": "table",
         "value": {
+          "title": "3rd-Level Spells",
           "headers": [
             "d6",
             "spell"
@@ -40110,6 +40242,7 @@
         "name": "4th-Level Spells",
         "type": "table",
         "value": {
+          "title": "4th-Level Spells",
           "headers": [
             "d4",
             "spell"
@@ -40138,6 +40271,7 @@
         "name": "5th-Level Spells",
         "type": "table",
         "value": {
+          "title": "5th-Level Spells",
           "headers": [
             "d4",
             "spell"
@@ -40307,6 +40441,7 @@
         "name": "Moonblade Properties",
         "type": "table",
         "value": {
+          "title": "Moonblade Properties",
           "headers": [
             "d100",
             "Property"
@@ -40528,6 +40663,7 @@
         "name": "Mournland Trinkets",
         "type": "table",
         "value": {
+          "title": "Mournland Trinkets",
           "headers": [
             "d10",
             "Trinket"
@@ -41176,6 +41312,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d20",
             "Bead of...",
@@ -41243,6 +41380,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d20",
             "Bead",
@@ -42062,6 +42200,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d6",
             "Reading"
@@ -42740,6 +42879,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -43254,6 +43394,7 @@
         "name": "Outer Essence Shards",
         "type": "table",
         "value": {
+          "title": "Outer Essence Shards",
           "headers": [
             "d4",
             "Property",
@@ -44840,6 +44981,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d6",
             "Trinket"
@@ -46831,7 +46973,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "When you drink this potion, your physical age is reduced by 1d6 + 6 years, to a minimum of 13 years. Each time you subsequently drink a potion of longevity, there is a 10|10 percent||You grow older!|You become younger percent cumulative chance that you instead age by 1d6 + 6 years. Suspended in this amber liquid are a scorpion's tail, an adder's fang, a dead spider, and a tiny heart that, against all reason, is still beating. These ingredients vanish when the potion is opened."
+        "value": "When you drink this potion, your physical age is reduced by 1d6 + 6 years, to a minimum of 13 years. Each time you subsequently drink a potion of longevity, there is a 10 percent cumulative chance that you instead age by 1d6 + 6 years. Suspended in this amber liquid are a scorpion's tail, an adder's fang, a dead spider, and a tiny heart that, against all reason, is still beating. These ingredients vanish when the potion is opened."
       }
     ],
     "properties": []
@@ -47795,7 +47937,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "*Depending on where and how it appears in the adventure, you might wish to modify the features of Kwalish's legendary powered armor.\n\n**Automatic Defenses**: Unless Kwalish deactivates the suit's automatic defenses, no one can approach the armor without setting those defenses off. Treat the armor as a __shield guardian__ that has stored a __magic missile__ spell cast using a 4th-level spell slot. When the armor is reduced to 0 hit points, its defenses are rendered inert and it can be safely approached.\n\n**Battle of Wills**: When donned by a new user, the armor deems itself superior and attempts to take possession of that user. The user must succeed on a DC 13 Charisma saving throw or be possessed by the armor. While possessed, the user is incapacitated and loses control of its body but retains its awareness. The armor uses the possessed user's statistics (as adjusted by the armor), but doesn't gain access to the user's knowledge, features, or proficiencies.\nFreeing a creature trapped inside the armor first requires defeating the armor's automatic defenses (as above). The trapped creature can also attempt a DC 20 Charisma saving throw each day at dawn. On a successful save, the armor no longer controls the creature and can be safely donned by that creature at any time.\n\n**Stasis**: Whenever a creature wearing the armor drops to 0 hit points, the armor places that creature into a state of stasis. While in this state, the creature is stable and does not make death saving throws, but the armor takes control of the creature (as above). Additionally, the armor attempts to assume the identity of the user, assuring their allies that nothing is amiss. Freeing the user first requires defeating the armor's automatic defenses (as above). A creature in stasis does not make Charisma saving throws to break the armor's control.\n\n**Alternative Power**: Powered armor originally required energy cells to fuel it, but was adapted by Kwalish to be fueled by the life energy of the creature wearing it. You might decide that the armor can also draw power from additional sources, or that energy cells can be recharged with the aid of a tinker, inventor, or artificer. It might also be possible for allies to connect to the armor through the use of magic that generates a conduit something like an astral silver cord. While so connected, a willing ally can give up hit points as a reaction to fuel the armor's abilities.*"
+        "value": "*Depending on where and how it appears in the adventure, you might wish to modify the features of Kwalish's legendary powered armor.*\n***Automatic Defenses**: Unless Kwalish deactivates the suit's automatic defenses, no one can approach the armor without setting those defenses off. Treat the armor as a __shield guardian__ that has stored a __magic missile__ spell cast using a 4th-level spell slot. When the armor is reduced to 0 hit points, its defenses are rendered inert and it can be safely approached.*\n***Battle of Wills**: When donned by a new user, the armor deems itself superior and attempts to take possession of that user. The user must succeed on a DC 13 Charisma saving throw or be possessed by the armor. While possessed, the user is incapacitated and loses control of its body but retains its awareness. The armor uses the possessed user's statistics (as adjusted by the armor), but doesn't gain access to the user's knowledge, features, or proficiencies.\nFreeing a creature trapped inside the armor first requires defeating the armor's automatic defenses (as above). The trapped creature can also attempt a DC 20 Charisma saving throw each day at dawn. On a successful save, the armor no longer controls the creature and can be safely donned by that creature at any time.*\n***Stasis**: Whenever a creature wearing the armor drops to 0 hit points, the armor places that creature into a state of stasis. While in this state, the creature is stable and does not make death saving throws, but the armor takes control of the creature (as above). Additionally, the armor attempts to assume the identity of the user, assuring their allies that nothing is amiss. Freeing the user first requires defeating the armor's automatic defenses (as above). A creature in stasis does not make Charisma saving throws to break the armor's control.*\n***Alternative Power**: Powered armor originally required energy cells to fuel it, but was adapted by Kwalish to be fueled by the life energy of the creature wearing it. You might decide that the armor can also draw power from additional sources, or that energy cells can be recharged with the aid of a tinker, inventor, or artificer. It might also be possible for allies to connect to the armor through the use of magic that generates a conduit something like an astral silver cord. While so connected, a willing ally can give up hit points as a reaction to fuel the armor's abilities.*"
       }
     ],
     "properties": []
@@ -48180,6 +48322,7 @@
         "name": "Prismari Trinkets",
         "type": "table",
         "value": {
+          "title": "Prismari Trinkets",
           "headers": [
             "d6",
             "Trinket"
@@ -48405,6 +48548,7 @@
         "name": "Psi Crystal Properties",
         "type": "table",
         "value": {
+          "title": "Psi Crystal Properties",
           "headers": [
             "Intelligence Score",
             "Range of Telepathy",
@@ -48676,6 +48820,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d8",
             "Calamity"
@@ -49060,6 +49205,7 @@
         "name": "Quandrix Trinkets",
         "type": "table",
         "value": {
+          "title": "Quandrix Trinkets",
           "headers": [
             "d6",
             "Trinket"
@@ -51456,6 +51602,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Number of Spheres",
             "Lightning Damage"
@@ -52463,6 +52610,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d100",
             "Patch"
@@ -52561,6 +52709,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d100",
             "Patch"
@@ -53193,6 +53342,7 @@
         "name": "Rod Pieces",
         "type": "table",
         "value": {
+          "title": "Rod Pieces",
           "headers": [
             "Piece",
             "Spell"
@@ -54744,6 +54894,7 @@
         "name": "Trinkets from Sarlona",
         "type": "table",
         "value": {
+          "title": "Trinkets from Sarlona",
           "headers": [
             "d8",
             "Trinket"
@@ -55841,6 +55992,7 @@
         "name": "Secondhand Steals",
         "type": "table",
         "value": {
+          "title": "Secondhand Steals",
           "headers": [
             "d8",
             "Secondhand Steal"
@@ -56036,6 +56188,7 @@
         "name": "Quirks of Your Sending Stone",
         "type": "table",
         "value": {
+          "title": "Quirks of Your Sending Stone",
           "headers": [
             "d8",
             "quirk"
@@ -56493,6 +56646,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d6",
             "Misfortune"
@@ -57981,6 +58135,7 @@
         "name": "Silverquill Trinkets",
         "type": "table",
         "value": {
+          "title": "Silverquill Trinkets",
           "headers": [
             "d6",
             "Trinket"
@@ -58468,6 +58623,7 @@
         "name": "Magic Sling Bullets",
         "type": "table",
         "value": {
+          "title": "Magic Sling Bullets",
           "headers": [
             "d4",
             "Bullet"
@@ -59190,6 +59346,7 @@
         "name": "Spaceship Trinkets",
         "type": "table",
         "value": {
+          "title": "Spaceship Trinkets",
           "headers": [
             "d100",
             "Trinket"
@@ -60759,7 +60916,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "*A spelljamming helm propels and steers a ship much as sails, oars, and rudders work on a seafaring vessel, and a spelljamming helm is easy to create if one has the proper spell. __Create spelljamming helm__ has a material component cost of 5,000 gp, so that's the least one can pay to acquire a spelljamming helm.\n\nWildspace merchants, including __dohwars__ and __mercanes__ (both described in Boo's Astral Menagerie), typically sell a spelljamming helm for substantially more than it cost to make. How much more depends on the market, but 7,500 gp would be a reasonable demand. A desperate buyer in a seller's market might pay 10,000 gp or more.*"
+        "value": "*A spelljamming helm propels and steers a ship much as sails, oars, and rudders work on a seafaring vessel, and a spelljamming helm is easy to create if one has the proper spell. __Create spelljamming helm__ has a material component cost of 5,000 gp, so that's the least one can pay to acquire a spelljamming helm.*\n*Wildspace merchants, including __dohwars__ and __mercanes__ (both described in Boo's Astral Menagerie), typically sell a spelljamming helm for substantially more than it cost to make. How much more depends on the market, but 7,500 gp would be a reasonable demand. A desperate buyer in a seller's market might pay 10,000 gp or more.*"
       },
       {
         "name": "Transfer Attunement",
@@ -61001,6 +61158,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d100",
             "Result"
@@ -61064,6 +61222,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d100",
             "Result"
@@ -61351,6 +61510,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -62008,6 +62168,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -62183,6 +62344,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -62284,6 +62446,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -62372,6 +62535,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Distance from Origin",
             "Effect"
@@ -62430,6 +62594,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -62708,6 +62873,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -62961,6 +63127,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Distance from Origin",
             "Damage"
@@ -63024,6 +63191,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -63337,6 +63505,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -65590,7 +65759,163 @@
       {
         "name": "",
         "type": "text",
-        "value": "• **Angelic Language**: You can speak, read, and write Celestial.\n• **Celestial Resistance**: You have resistance to necrotic and radiant damage.\n• **Divine Presence**: Your Charisma score becomes 20, unless it is already 20 or higher.\n• **Feathered Wings**: You sprout a beautiful pair of feathered wings that grant you a flying speed of 90 feet and the ability to hover. If you already have a different kind of wings, these new wings replace the old ones, which fall off.\n• **Truesight**: Your eyes become luminous pools of silver. You can see in normal and magical darkness, see invisible creatures and objects, automatically detect visual illusions and succeed on saving throws against them, perceive the original form of a shapechanger or a creature that is transformed by magic, and see into the Ethereal Plane, all within a range of 60 feet.\n• **New Personality**: You gain new personality traits, determined by rolling once on each of the following tables. These traits override any conflicting personality trait, ideal, bond, or flaw.\n[object Object]\n[object Object]\n[object Object]\n[object Object]"
+        "value": "• **Angelic Language**: You can speak, read, and write Celestial.\n• **Celestial Resistance**: You have resistance to necrotic and radiant damage.\n• **Divine Presence**: Your Charisma score becomes 20, unless it is already 20 or higher.\n• **Feathered Wings**: You sprout a beautiful pair of feathered wings that grant you a flying speed of 90 feet and the ability to hover. If you already have a different kind of wings, these new wings replace the old ones, which fall off.\n• **Truesight**: Your eyes become luminous pools of silver. You can see in normal and magical darkness, see invisible creatures and objects, automatically detect visual illusions and succeed on saving throws against them, perceive the original form of a shapechanger or a creature that is transformed by magic, and see into the Ethereal Plane, all within a range of 60 feet.\n• **New Personality**: You gain new personality traits, determined by rolling once on each of the following tables. These traits override any conflicting personality trait, ideal, bond, or flaw."
+      },
+      {
+        "name": "Personality Traits",
+        "type": "table",
+        "value": {
+          "title": "Personality Traits",
+          "headers": [
+            "d8",
+            "Personality Trait"
+          ],
+          "rows": [
+            [
+              "1",
+              "I treat all beings, even enemies, with respect."
+            ],
+            [
+              "2",
+              "I won't tell a lie."
+            ],
+            [
+              "3",
+              "I enjoy sharing my philosophical worldview and experiences with others."
+            ],
+            [
+              "4",
+              "I cut right to the chase in every conversation."
+            ],
+            [
+              "5",
+              "I often quote (or misquote) religious texts."
+            ],
+            [
+              "6",
+              "I anger quickly when I witness cruelty or injustice."
+            ],
+            [
+              "7",
+              "My praise and trust are earned and never given freely."
+            ],
+            [
+              "8",
+              "I like everything clean and organized."
+            ]
+          ]
+        }
+      },
+      {
+        "name": "Ideals",
+        "type": "table",
+        "value": {
+          "title": "Ideals",
+          "headers": [
+            "d6",
+            "Ideal"
+          ],
+          "rows": [
+            [
+              "1",
+              "Charity. I always help those in need. (Good)"
+            ],
+            [
+              "2",
+              "Faith. I choose to follow the tenets of a particular lawful good deity to the letter. (Lawful)"
+            ],
+            [
+              "3",
+              "Responsibility. It is the duty of the strong to protect the weak. (Lawful)"
+            ],
+            [
+              "4",
+              "Respect. All people deserve to be treated with dignity. (Good)"
+            ],
+            [
+              "5",
+              "Honor. The way I conduct myself determines my reward in the afterlife. (Lawful)"
+            ],
+            [
+              "6",
+              "Redemption. All creatures are capable of change for the better. (Good)"
+            ]
+          ]
+        }
+      },
+      {
+        "name": "Bonds",
+        "type": "table",
+        "value": {
+          "title": "Bonds",
+          "headers": [
+            "d6",
+            "Bond"
+          ],
+          "rows": [
+            [
+              "1",
+              "I have a favorite religious hymn that I constantly hum."
+            ],
+            [
+              "2",
+              "I must keep a written record of my beliefs and the sins that I witness. When finished, this book will be my gift to the multiverse."
+            ],
+            [
+              "3",
+              "I have cherished memories of Idyllglen, though I've only seen this bucolic town in dreams."
+            ],
+            [
+              "4",
+              "I would die for those who fight beside me, regardless of their faults."
+            ],
+            [
+              "5",
+              "I seek to honor the angel Zariel by destroying fiends and other evildoers wherever I find them."
+            ],
+            [
+              "6",
+              "The Sword of Zariel has chosen me. I shall not fail to wield it justly."
+            ]
+          ]
+        }
+      },
+      {
+        "name": "Flaws",
+        "type": "table",
+        "value": {
+          "title": "Flaws",
+          "headers": [
+            "d6",
+            "Flaw"
+          ],
+          "rows": [
+            [
+              "1",
+              "I am too quick to judge others."
+            ],
+            [
+              "2",
+              "I offer forgiveness too readily."
+            ],
+            [
+              "3",
+              "I will sacrifice innocent lives for the greater good."
+            ],
+            [
+              "4",
+              "Flaw? What flaw? I am flawless. Utter perfection!"
+            ],
+            [
+              "5",
+              "I allow nothing to stand in the way of my crusade to eradicate evil from the multiverse."
+            ],
+            [
+              "6",
+              "I ignore those who do not support my plans, for my calling is higher than all others."
+            ]
+          ]
+        }
       },
       {
         "name": "Holy Light",
@@ -66150,6 +66475,7 @@
         "name": "Teeth of Dahlver-Nar",
         "type": "table",
         "value": {
+          "title": "Teeth of Dahlver-Nar",
           "headers": [
             "d20",
             "Tale and Tooth",
@@ -66393,6 +66719,7 @@
         "name": "Telescope Travel Mishaps",
         "type": "table",
         "value": {
+          "title": "Telescope Travel Mishaps",
           "headers": [
             "d6",
             "Mishap"
@@ -66679,6 +67006,7 @@
         "name": "Infernal Machine Properties",
         "type": "table",
         "value": {
+          "title": "Infernal Machine Properties",
           "headers": [
             "d100",
             "Beneficial Property",
@@ -68475,6 +68803,7 @@
         "name": "Acquisitions Incorporated Trinkets",
         "type": "table",
         "value": {
+          "title": "Acquisitions Incorporated Trinkets",
           "headers": [
             "d100",
             "Trinket"
@@ -68905,6 +69234,7 @@
         "name": "Curse of Strahd. Character Options, Gothic Trinket Table",
         "type": "table",
         "value": {
+          "title": "Curse of Strahd. Character Options, Gothic Trinket Table",
           "headers": [
             "d100",
             "Trinket"
@@ -69135,6 +69465,7 @@
         "name": "Elemental Evil Trinket Table",
         "type": "table",
         "value": {
+          "title": "Elemental Evil Trinket Table",
           "headers": [
             "d100",
             "Trinket"
@@ -69565,6 +69896,7 @@
         "name": "Player's Handbook Trinket Table",
         "type": "table",
         "value": {
+          "title": "Player's Handbook Trinket Table",
           "headers": [
             "d100",
             "Trinket"
@@ -69995,6 +70327,7 @@
         "name": "Trinkets",
         "type": "table",
         "value": {
+          "title": "Trinkets",
           "headers": [
             "1d100",
             "Trinket"
@@ -71374,6 +71707,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -71572,6 +71906,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -71950,6 +72285,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Spell",
             "Charge Cost"
@@ -72417,6 +72753,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d100",
             "Effect"
@@ -72541,6 +72878,7 @@
         "name": "Wand of Wonder Effects",
         "type": "table",
         "value": {
+          "title": "Wand of Wonder Effects",
           "headers": [
             "1d100",
             "Effect"
@@ -73629,6 +73967,7 @@
         "name": "Things Recorded in Your Whisper Jar",
         "type": "table",
         "value": {
+          "title": "Things Recorded in Your Whisper Jar",
           "headers": [
             "d8",
             "Recording"
@@ -73979,6 +74318,7 @@
         "name": "Will of the Talon Breath Weapons",
         "type": "table",
         "value": {
+          "title": "Will of the Talon Breath Weapons",
           "headers": [
             "Damage Type",
             "Area",
@@ -74417,6 +74757,7 @@
         "name": "Witherbloom Trinkets",
         "type": "table",
         "value": {
+          "title": "Witherbloom Trinkets",
           "headers": [
             "d6",
             "Trinket"
@@ -74895,6 +75236,7 @@
         "name": "Trinkets from Xen'drik",
         "type": "table",
         "value": {
+          "title": "Trinkets from Xen'drik",
           "headers": [
             "d8",
             "Trinket"

--- a/generated/rules.json
+++ b/generated/rules.json
@@ -208,6 +208,7 @@
         "name": "Figuring Out Alien Technology",
         "type": "table",
         "value": {
+          "title": "Figuring Out Alien Technology",
           "headers": [
             "Int. Check Total",
             "Result"
@@ -584,6 +585,7 @@
         "name": "Object Armor Class",
         "type": "table",
         "value": {
+          "title": "Object Armor Class",
           "headers": [
             "AC",
             "Substance"
@@ -629,6 +631,7 @@
         "name": "Object Hit Points",
         "type": "table",
         "value": {
+          "title": "Object Hit Points",
           "headers": [
             "Size",
             "Fragile",
@@ -747,6 +750,7 @@
         "name": "Carrying Capacity",
         "type": "table",
         "value": {
+          "title": "Carrying Capacity",
           "headers": [
             "Creature Size",
             "Carry",
@@ -755,28 +759,28 @@
           "rows": [
             [
               "Tiny",
-              "#$prompt_number:title=Enter Strength Score$# × 7.5 (Str. × 7.5) lb.",
-              "#$prompt_number:title=Enter Strength Score$# × 15 (Str. × 15) lb."
+              "Str. × 7.5 lb.",
+              "Str. × 15 lb."
             ],
             [
               "Small/Medium",
-              "#$prompt_number:title=Enter Strength Score$# × 15 (Str. × 15) lb.",
-              "#$prompt_number:title=Enter Strength Score$# × 30 (Str. × 30) lb."
+              "Str. × 15 lb.",
+              "Str. × 30 lb."
             ],
             [
               "Large",
-              "#$prompt_number:title=Enter Strength Score$# × 30 (Str. × 30) lb.",
-              "#$prompt_number:title=Enter Strength Score$# × 60 (Str. × 60) lb."
+              "Str. × 30 lb.",
+              "Str. × 60 lb."
             ],
             [
               "Huge",
-              "#$prompt_number:title=Enter Strength Score$# × 60 (Str. × 60) lb.",
-              "#$prompt_number:title=Enter Strength Score$# × 120 (Str. × 120) lb."
+              "Str. × 60 lb.",
+              "Str. × 120 lb."
             ],
             [
               "Gargantuan",
-              "#$prompt_number:title=Enter Strength Score$# × 120 (Str. × 120) lb.",
-              "#$prompt_number:title=Enter Strength Score$# × 240 (Str. × 240) lb."
+              "Str. × 120 lb.",
+              "Str. × 240 lb."
             ]
           ]
         }
@@ -932,6 +936,7 @@
         "name": "Crash Damage",
         "type": "table",
         "value": {
+          "title": "Crash Damage",
           "headers": [
             "Size of Creature or Object Struck",
             "Bludgeoning Damage"
@@ -1090,6 +1095,7 @@
         "name": "Ability Score Point Cost",
         "type": "table",
         "value": {
+          "title": "Ability Score Point Cost",
           "headers": [
             "Score",
             "Cost"
@@ -1192,6 +1198,7 @@
         "name": "Proficiency Swaps",
         "type": "table",
         "value": {
+          "title": "Proficiency Swaps",
           "headers": [
             "Proficiency",
             "Replacement Proficiency"
@@ -1228,7 +1235,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "*Instead of choosing one of the game's races for your character at 1st level, you can use the following traits to represent your character's lineage, giving you full control over how your character's origin shaped them:\n\n• **Creature Type**: You are a humanoid. You determine your appearance and whether you resemble any of your kin.\n• **Size**: You are Small or Medium (your choice).\n• **Speed**: Your base walking speed is 30 feet.\n• **Ability Score Increase**: One ability score of your choice increases by 2.\n• **Feat**: You gain one feat of your choice for which you qualify.\n• **Variable Trait**: You gain one of the following options of your choice: (a) darkvision with a range of 60 feet or (b) proficiency in one skill of your choice.\n• **Languages**: You can speak, read, and write Common and one other language that you and your DM agree is appropriate for your character.*"
+        "value": "*Instead of choosing one of the game's races for your character at 1st level, you can use the following traits to represent your character's lineage, giving you full control over how your character's origin shaped them:*\n*• **Creature Type**: You are a humanoid. You determine your appearance and whether you resemble any of your kin.\n• **Size**: You are Small or Medium (your choice).\n• **Speed**: Your base walking speed is 30 feet.\n• **Ability Score Increase**: One ability score of your choice increases by 2.\n• **Feat**: You gain one feat of your choice for which you qualify.\n• **Variable Trait**: You gain one of the following options of your choice: (a) darkvision with a range of 60 feet or (b) proficiency in one skill of your choice.\n• **Languages**: You can speak, read, and write Common and one other language that you and your DM agree is appropriate for your character.*"
       }
     ]
   },
@@ -1317,6 +1324,7 @@
         "name": "Damage Types",
         "type": "table",
         "value": {
+          "title": "Damage Types",
           "headers": [
             "Type",
             "Examples"
@@ -1556,6 +1564,7 @@
         "name": "Building a Stronghold",
         "type": "table",
         "value": {
+          "title": "Building a Stronghold",
           "headers": [
             "Stronghold",
             "Construction Cost",
@@ -1657,6 +1666,7 @@
         "name": "Buying Magic Items",
         "type": "table",
         "value": {
+          "title": "Buying Magic Items",
           "headers": [
             "Check Total",
             "Items Acquired"
@@ -1705,6 +1715,7 @@
         "name": "Magic Item Price",
         "type": "table",
         "value": {
+          "title": "Magic Item Price",
           "headers": [
             "Rarity",
             "Asking Price*"
@@ -1742,6 +1753,7 @@
         "name": "Magic Item Purchase Complications",
         "type": "table",
         "value": {
+          "title": "Magic Item Purchase Complications",
           "headers": [
             "d12",
             "Complication"
@@ -1820,6 +1832,7 @@
         "name": "Carousing",
         "type": "table",
         "value": {
+          "title": "Carousing",
           "headers": [
             "d100 + Level",
             "Result"
@@ -1938,6 +1951,7 @@
         "name": "Carousing",
         "type": "table",
         "value": {
+          "title": "Carousing",
           "headers": [
             "Check Total",
             "Result"
@@ -1975,6 +1989,7 @@
         "name": "Lower-Class Carousing Complications",
         "type": "table",
         "value": {
+          "title": "Lower-Class Carousing Complications",
           "headers": [
             "d8",
             "Complication"
@@ -2019,6 +2034,7 @@
         "name": "Middle-Class Carousing Complications",
         "type": "table",
         "value": {
+          "title": "Middle-Class Carousing Complications",
           "headers": [
             "d8",
             "Complication"
@@ -2063,6 +2079,7 @@
         "name": "Upper-Class Carousing Complications",
         "type": "table",
         "value": {
+          "title": "Upper-Class Carousing Complications",
           "headers": [
             "d8",
             "Complication"
@@ -2182,12 +2199,13 @@
       {
         "name": "",
         "type": "text",
-        "value": "*A magic item formula explains how to make a particular magic item. Such a formula can be an excellent reward if you allow player characters to craft magic items.\n\nYou can award a formula in place of a magic item. Usually written in a book or on a scroll, a formula is one step rarer than the item it allows a character to create. For example, the formula for a common magic item is uncommon. No formulas exist for legendary items.\n\nIf the creation of magic items is commonplace in your campaign, a formula can have a rarity that matches the rarity of the item it allows a character to create. Formulas for common and uncommon items might even be for sale, each with a cost double that of its magic item.*"
+        "value": "*A magic item formula explains how to make a particular magic item. Such a formula can be an excellent reward if you allow player characters to craft magic items.*\n*You can award a formula in place of a magic item. Usually written in a book or on a scroll, a formula is one step rarer than the item it allows a character to create. For example, the formula for a common magic item is uncommon. No formulas exist for legendary items.*\n*If the creation of magic items is commonplace in your campaign, a formula can have a rarity that matches the rarity of the item it allows a character to create. Formulas for common and uncommon items might even be for sale, each with a cost double that of its magic item.*"
       },
       {
         "name": "Crafting Magic Items",
         "type": "table",
         "value": {
+          "title": "Crafting Magic Items",
           "headers": [
             "Item Rarity",
             "Creation Cost",
@@ -2259,6 +2277,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Proficiency",
             "Items"
@@ -2332,6 +2351,7 @@
         "name": "Magic Item Ingredients",
         "type": "table",
         "value": {
+          "title": "Magic Item Ingredients",
           "headers": [
             "Item Rarity",
             "CR Range"
@@ -2364,6 +2384,7 @@
         "name": "Magic Item Crafting Time and Cost",
         "type": "table",
         "value": {
+          "title": "Magic Item Crafting Time and Cost",
           "headers": [
             "Item Rarity",
             "Workweeks*",
@@ -2407,6 +2428,7 @@
         "name": "Crafting Complications",
         "type": "table",
         "value": {
+          "title": "Crafting Complications",
           "headers": [
             "d6",
             "Complication"
@@ -2448,6 +2470,7 @@
         "name": "Potion of Healing Creation",
         "type": "table",
         "value": {
+          "title": "Potion of Healing Creation",
           "headers": [
             "Type",
             "Time",
@@ -2534,6 +2557,7 @@
         "name": "Loot Value",
         "type": "table",
         "value": {
+          "title": "Loot Value",
           "headers": [
             "DC",
             "Value"
@@ -2567,6 +2591,7 @@
         "name": "Crime Complications",
         "type": "table",
         "value": {
+          "title": "Crime Complications",
           "headers": [
             "d8",
             "Complication"
@@ -2652,6 +2677,7 @@
         "name": "Gambling Results",
         "type": "table",
         "value": {
+          "title": "Gambling Results",
           "headers": [
             "Result",
             "Value"
@@ -2685,6 +2711,7 @@
         "name": "Gambling Complications",
         "type": "table",
         "value": {
+          "title": "Gambling Complications",
           "headers": [
             "d6",
             "Complication"
@@ -2772,6 +2799,7 @@
         "name": "Pit Fighting Results",
         "type": "table",
         "value": {
+          "title": "Pit Fighting Results",
           "headers": [
             "Result",
             "Value"
@@ -2805,6 +2833,7 @@
         "name": "Pit Fighting Complications",
         "type": "table",
         "value": {
+          "title": "Pit Fighting Complications",
           "headers": [
             "d6",
             "Complication"
@@ -2948,6 +2977,7 @@
         "name": "Religious Service",
         "type": "table",
         "value": {
+          "title": "Religious Service",
           "headers": [
             "Check Total",
             "Result"
@@ -2977,6 +3007,7 @@
         "name": "Religious Service Complications",
         "type": "table",
         "value": {
+          "title": "Religious Service Complications",
           "headers": [
             "d6",
             "Complication"
@@ -3046,6 +3077,7 @@
         "name": "Research Outcomes",
         "type": "table",
         "value": {
+          "title": "Research Outcomes",
           "headers": [
             "Check Total",
             "Outcome"
@@ -3084,6 +3116,7 @@
         "name": "Research Complications",
         "type": "table",
         "value": {
+          "title": "Research Complications",
           "headers": [
             "d6",
             "Complication"
@@ -3166,6 +3199,7 @@
         "name": "Running a Business",
         "type": "table",
         "value": {
+          "title": "Running a Business",
           "headers": [
             "d100 + Days",
             "Result"
@@ -3229,6 +3263,7 @@
         "name": "Spell Scroll Costs",
         "type": "table",
         "value": {
+          "title": "Spell Scroll Costs",
           "headers": [
             "Spell Level",
             "Time",
@@ -3297,6 +3332,7 @@
         "name": "Scribe a Scroll Complications",
         "type": "table",
         "value": {
+          "title": "Scribe a Scroll Complications",
           "headers": [
             "d6",
             "Complication"
@@ -3356,6 +3392,7 @@
         "name": "Magic Item Base Prices",
         "type": "table",
         "value": {
+          "title": "Magic Item Base Prices",
           "headers": [
             "Rarity",
             "Base Price*"
@@ -3388,6 +3425,7 @@
         "name": "Magic Item Offer",
         "type": "table",
         "value": {
+          "title": "Magic Item Offer",
           "headers": [
             "Check Total",
             "Offer"
@@ -3417,6 +3455,7 @@
         "name": "Magic Item Sale Complications",
         "type": "table",
         "value": {
+          "title": "Magic Item Sale Complications",
           "headers": [
             "d6",
             "Complication"
@@ -3491,6 +3530,7 @@
         "name": "Salable Magic Items",
         "type": "table",
         "value": {
+          "title": "Salable Magic Items",
           "headers": [
             "Rarity",
             "Base Price",
@@ -3529,6 +3569,7 @@
         "name": "Selling a Magic Item",
         "type": "table",
         "value": {
+          "title": "Selling a Magic Item",
           "headers": [
             "d100 + Mod",
             "You Find..."
@@ -3589,6 +3630,7 @@
         "name": "Sowing Rumors",
         "type": "table",
         "value": {
+          "title": "Sowing Rumors",
           "headers": [
             "Settlement Size",
             "Time Required"
@@ -3659,6 +3701,7 @@
         "name": "Training Complications",
         "type": "table",
         "value": {
+          "title": "Training Complications",
           "headers": [
             "d6",
             "Complication"
@@ -3713,6 +3756,7 @@
         "name": "Training to Gain Levels",
         "type": "table",
         "value": {
+          "title": "Training to Gain Levels",
           "headers": [
             "Level Attained",
             "Training Time",
@@ -3769,6 +3813,7 @@
         "name": "Wages",
         "type": "table",
         "value": {
+          "title": "Wages",
           "headers": [
             "Check Total",
             "Earnings"
@@ -3802,6 +3847,7 @@
         "name": "Work Complications",
         "type": "table",
         "value": {
+          "title": "Work Complications",
           "headers": [
             "d6",
             "Complication"
@@ -3861,6 +3907,7 @@
         "name": "Exploration Discoveries",
         "type": "table",
         "value": {
+          "title": "Exploration Discoveries",
           "headers": [
             "Check Total",
             "Discovery"
@@ -3941,6 +3988,7 @@
         "name": "Explore Territory Complications",
         "type": "table",
         "value": {
+          "title": "Explore Territory Complications",
           "headers": [
             "d6",
             "Complication"
@@ -4015,6 +4063,7 @@
         "name": "Franchise Restructuring",
         "type": "table",
         "value": {
+          "title": "Franchise Restructuring",
           "headers": [
             "Successes",
             "Benefit"
@@ -4044,6 +4093,7 @@
         "name": "Franchise Restructuring Complications",
         "type": "table",
         "value": {
+          "title": "Franchise Restructuring Complications",
           "headers": [
             "d6",
             "Complication"
@@ -4113,6 +4163,7 @@
         "name": "Headquarters Modification",
         "type": "table",
         "value": {
+          "title": "Headquarters Modification",
           "headers": [
             "Successes",
             "Benefit"
@@ -4146,6 +4197,7 @@
         "name": "Headquarters Modification Complications",
         "type": "table",
         "value": {
+          "title": "Headquarters Modification Complications",
           "headers": [
             "d6",
             "Complication"
@@ -4215,6 +4267,7 @@
         "name": "Marketeering",
         "type": "table",
         "value": {
+          "title": "Marketeering",
           "headers": [
             "Successes",
             "Benefit"
@@ -4248,6 +4301,7 @@
         "name": "Marketeering Complications",
         "type": "table",
         "value": {
+          "title": "Marketeering Complications",
           "headers": [
             "d8",
             "Complication"
@@ -4320,6 +4374,7 @@
         "name": "Philanthropic Enterprise",
         "type": "table",
         "value": {
+          "title": "Philanthropic Enterprise",
           "headers": [
             "Check Total",
             "Result"
@@ -4362,6 +4417,7 @@
         "name": "Philanthropic Enterprise Complications",
         "type": "table",
         "value": {
+          "title": "Philanthropic Enterprise Complications",
           "headers": [
             "d6",
             "Complication"
@@ -4426,6 +4482,7 @@
         "name": "Running a Franchise",
         "type": "table",
         "value": {
+          "title": "Running a Franchise",
           "headers": [
             "d100 + Days",
             "Result"
@@ -4503,6 +4560,7 @@
         "name": "Running a Franchise Complications",
         "type": "table",
         "value": {
+          "title": "Running a Franchise Complications",
           "headers": [
             "d6",
             "Complication"
@@ -4567,6 +4625,7 @@
         "name": "Schmoozing",
         "type": "table",
         "value": {
+          "title": "Schmoozing",
           "headers": [
             "Check Total",
             "Result"
@@ -4604,6 +4663,7 @@
         "name": "Schmoozing Complications",
         "type": "table",
         "value": {
+          "title": "Schmoozing Complications",
           "headers": [
             "d6",
             "Complication"
@@ -4668,6 +4728,7 @@
         "name": "Scrutineering",
         "type": "table",
         "value": {
+          "title": "Scrutineering",
           "headers": [
             "Check Total",
             "Outcome"
@@ -4701,6 +4762,7 @@
         "name": "Scrutineering Complications",
         "type": "table",
         "value": {
+          "title": "Scrutineering Complications",
           "headers": [
             "d6",
             "Complication"
@@ -4775,6 +4837,7 @@
         "name": "Shady Business Practice",
         "type": "table",
         "value": {
+          "title": "Shady Business Practice",
           "headers": [
             "Successes",
             "Benefit"
@@ -4808,6 +4871,7 @@
         "name": "Shady Business Practice Complications",
         "type": "table",
         "value": {
+          "title": "Shady Business Practice Complications",
           "headers": [
             "d6",
             "Complication"
@@ -4882,6 +4946,7 @@
         "name": "Team Building",
         "type": "table",
         "value": {
+          "title": "Team Building",
           "headers": [
             "Check Total",
             "Benefit"
@@ -4934,6 +4999,7 @@
         "name": "Team Building Complications",
         "type": "table",
         "value": {
+          "title": "Team Building Complications",
           "headers": [
             "d6",
             "Complication"
@@ -5028,6 +5094,7 @@
         "name": "Rival",
         "type": "table",
         "value": {
+          "title": "Rival",
           "headers": [
             "d20",
             "Rival"
@@ -5302,6 +5369,7 @@
         "name": "Open Water Encounters (Levels 1–4)",
         "type": "table",
         "value": {
+          "title": "Open Water Encounters (Levels 1–4)",
           "headers": [
             "d100",
             "Encounter"
@@ -5414,6 +5482,7 @@
         "name": "Open Water Encounters (Levels 5–10)",
         "type": "table",
         "value": {
+          "title": "Open Water Encounters (Levels 5–10)",
           "headers": [
             "d100",
             "Encounter"
@@ -5530,6 +5599,7 @@
         "name": "Open Water Encounters (Levels 11–20)",
         "type": "table",
         "value": {
+          "title": "Open Water Encounters (Levels 11–20)",
           "headers": [
             "d100",
             "Encounter"
@@ -5929,6 +5999,7 @@
         "name": "Seeds of Fear",
         "type": "table",
         "value": {
+          "title": "Seeds of Fear",
           "headers": [
             "d12",
             "Seed"
@@ -6781,6 +6852,7 @@
         "name": "Speed Factor Initiative Modifiers",
         "type": "table",
         "value": {
+          "title": "Speed Factor Initiative Modifiers",
           "headers": [
             "Factor",
             "Initiative Modifier"
@@ -6813,6 +6885,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Creature Size",
             "Initiative Modifier"
@@ -6897,6 +6970,7 @@
         "name": "Lingering Injuries",
         "type": "table",
         "value": {
+          "title": "Lingering Injuries",
           "headers": [
             "d20",
             "Injury"
@@ -7358,6 +7432,7 @@
         "name": "Short-Term Madness",
         "type": "table",
         "value": {
+          "title": "Short-Term Madness",
           "headers": [
             "d100",
             "Effects (lasts 1d10 minutes)"
@@ -7410,6 +7485,7 @@
         "name": "Long-Term Madness",
         "type": "table",
         "value": {
+          "title": "Long-Term Madness",
           "headers": [
             "d100",
             "Effects (lasts 1d10 × 10 hours)"
@@ -7470,6 +7546,7 @@
         "name": "Indefinite Madness",
         "type": "table",
         "value": {
+          "title": "Indefinite Madness",
           "headers": [
             "d100",
             "Flaw (lasts until cured)"
@@ -7566,6 +7643,7 @@
         "name": "System Shock",
         "type": "table",
         "value": {
+          "title": "System Shock",
           "headers": [
             "d10",
             "Effect"
@@ -7662,6 +7740,7 @@
         "name": "Potion Miscibility",
         "type": "table",
         "value": {
+          "title": "Potion Miscibility",
           "headers": [
             "d100",
             "Result"
@@ -7808,6 +7887,7 @@
         "name": "Multiclassing Prerequisites",
         "type": "table",
         "value": {
+          "title": "Multiclassing Prerequisites",
           "headers": [
             "Class",
             "Ability Score Minimum"
@@ -7893,6 +7973,7 @@
         "name": "Multiclassing Proficiencies",
         "type": "table",
         "value": {
+          "title": "Multiclassing Proficiencies",
           "headers": [
             "Class",
             "Proficiencies Gained"
@@ -8008,6 +8089,7 @@
         "name": "Multiclass Spellcaster: Spell Slots per Spell Level",
         "type": "table",
         "value": {
+          "title": "Multiclass Spellcaster: Spell Slots per Spell Level",
           "headers": [
             "Lvl.",
             "1st",
@@ -8341,6 +8423,7 @@
         "name": "Multiclass Spellcaster: Spell Slots per Spell Level",
         "type": "table",
         "value": {
+          "title": "Multiclass Spellcaster: Spell Slots per Spell Level",
           "headers": [
             "Level",
             "1",
@@ -8674,6 +8757,7 @@
         "name": "Island Theme",
         "type": "table",
         "value": {
+          "title": "Island Theme",
           "headers": [
             "d6",
             "Theme"
@@ -8715,6 +8799,7 @@
         "name": "Alien Island Leader",
         "type": "table",
         "value": {
+          "title": "Alien Island Leader",
           "headers": [
             "d4",
             "Leader"
@@ -8743,6 +8828,7 @@
         "name": "Alien Island Inhabitants",
         "type": "table",
         "value": {
+          "title": "Alien Island Inhabitants",
           "headers": [
             "d6",
             "Inhabitants"
@@ -8775,6 +8861,7 @@
         "name": "Alien Inhabitant Reactions",
         "type": "table",
         "value": {
+          "title": "Alien Inhabitant Reactions",
           "headers": [
             "d6",
             "Reaction"
@@ -8811,6 +8898,7 @@
         "name": "Alien Island Story Hooks",
         "type": "table",
         "value": {
+          "title": "Alien Island Story Hooks",
           "headers": [
             "d4",
             "Story Hook"
@@ -8844,6 +8932,7 @@
         "name": "Island Curses",
         "type": "table",
         "value": {
+          "title": "Island Curses",
           "headers": [
             "d6",
             "Curse"
@@ -8880,6 +8969,7 @@
         "name": "Cursed Island Inhabitants",
         "type": "table",
         "value": {
+          "title": "Cursed Island Inhabitants",
           "headers": [
             "d6",
             "Inhabitants"
@@ -8916,6 +9006,7 @@
         "name": "Cursed Island Story Hooks",
         "type": "table",
         "value": {
+          "title": "Cursed Island Story Hooks",
           "headers": [
             "d4",
             "Story Hook"
@@ -8949,6 +9040,7 @@
         "name": "Hostile Island Leader",
         "type": "table",
         "value": {
+          "title": "Hostile Island Leader",
           "headers": [
             "d6",
             "Leader"
@@ -8985,6 +9077,7 @@
         "name": "Hostile Island Leader Motivations",
         "type": "table",
         "value": {
+          "title": "Hostile Island Leader Motivations",
           "headers": [
             "d4",
             "Motivation"
@@ -9013,6 +9106,7 @@
         "name": "Hostile Inhabitants",
         "type": "table",
         "value": {
+          "title": "Hostile Inhabitants",
           "headers": [
             "d6",
             "Inhabitants"
@@ -9049,6 +9143,7 @@
         "name": "Hostile Island Story Hooks",
         "type": "table",
         "value": {
+          "title": "Hostile Island Story Hooks",
           "headers": [
             "d4",
             "Story Hook"
@@ -9082,6 +9177,7 @@
         "name": "Sanctum Island Leader",
         "type": "table",
         "value": {
+          "title": "Sanctum Island Leader",
           "headers": [
             "d6",
             "Leader"
@@ -9118,6 +9214,7 @@
         "name": "Sanctum Island Inhabitants",
         "type": "table",
         "value": {
+          "title": "Sanctum Island Inhabitants",
           "headers": [
             "d6",
             "Inhabitants"
@@ -9154,6 +9251,7 @@
         "name": "Sanctum Island Reactions",
         "type": "table",
         "value": {
+          "title": "Sanctum Island Reactions",
           "headers": [
             "d6",
             "Reaction"
@@ -9190,6 +9288,7 @@
         "name": "Sanctum Island Story Hooks",
         "type": "table",
         "value": {
+          "title": "Sanctum Island Story Hooks",
           "headers": [
             "d4",
             "Story Hook"
@@ -9223,6 +9322,7 @@
         "name": "Welcoming Island Leader",
         "type": "table",
         "value": {
+          "title": "Welcoming Island Leader",
           "headers": [
             "d6",
             "Leader"
@@ -9259,6 +9359,7 @@
         "name": "Welcoming Island Inhabitants",
         "type": "table",
         "value": {
+          "title": "Welcoming Island Inhabitants",
           "headers": [
             "d6",
             "Inhabitants"
@@ -9295,6 +9396,7 @@
         "name": "Welcoming Island Story Hooks",
         "type": "table",
         "value": {
+          "title": "Welcoming Island Story Hooks",
           "headers": [
             "d4",
             "Story Hook"
@@ -9328,6 +9430,7 @@
         "name": "Wild Island Features",
         "type": "table",
         "value": {
+          "title": "Wild Island Features",
           "headers": [
             "d6",
             "Feature"
@@ -9364,6 +9467,7 @@
         "name": "Wild Island Encounters",
         "type": "table",
         "value": {
+          "title": "Wild Island Encounters",
           "headers": [
             "d20",
             "Encounter"
@@ -9456,6 +9560,7 @@
         "name": "Wild Island Story Hooks",
         "type": "table",
         "value": {
+          "title": "Wild Island Story Hooks",
           "headers": [
             "d4",
             "Story Hook"
@@ -9649,6 +9754,7 @@
         "name": "Hiding in Blue Holes",
         "type": "table",
         "value": {
+          "title": "Hiding in Blue Holes",
           "headers": [
             "d10",
             "Creatures or Treasure"
@@ -9766,6 +9872,7 @@
         "name": "Objects and Water Pressure",
         "type": "table",
         "value": {
+          "title": "Objects and Water Pressure",
           "headers": [
             "Material",
             "Destructive Depth"
@@ -9812,6 +9919,7 @@
         "name": "Eldritch Mist Types",
         "type": "table",
         "value": {
+          "title": "Eldritch Mist Types",
           "headers": [
             "d6",
             "Mist Type"
@@ -9841,6 +9949,7 @@
         "name": "Mist Thickness",
         "type": "table",
         "value": {
+          "title": "Mist Thickness",
           "headers": [
             "d10",
             "Thickness"
@@ -9869,6 +9978,7 @@
         "name": "Mist Obfuscation",
         "type": "table",
         "value": {
+          "title": "Mist Obfuscation",
           "headers": [
             "Thickness",
             "Heavily Obscured Distance"
@@ -9977,6 +10087,7 @@
         "name": "Magical Storm Type",
         "type": "table",
         "value": {
+          "title": "Magical Storm Type",
           "headers": [
             "d8",
             "Magic"
@@ -10071,6 +10182,7 @@
         "name": "Sandbar DCs",
         "type": "table",
         "value": {
+          "title": "Sandbar DCs",
           "headers": [
             "DC",
             "Description"
@@ -10110,6 +10222,7 @@
         "name": "Shipwreck Contents",
         "type": "table",
         "value": {
+          "title": "Shipwreck Contents",
           "headers": [
             "d10",
             "Creatures or Treasure"
@@ -10167,6 +10280,7 @@
         "name": "Whirlpool Rank",
         "type": "table",
         "value": {
+          "title": "Whirlpool Rank",
           "headers": [
             "Rank",
             "Diameter",
@@ -10202,7 +10316,7 @@
         }
       },
       {
-        "name": "",
+        "name": "Creatures in Whirlpools",
         "type": "text",
         "value": "When a creature moves into a whirlpool or starts its turn there, it must make a Strength (*Athletics*) check with a DC determined by the whirlpool's rank. On a success, the creature can move normally. On a failure, the creature is immediately moved toward the vortex's center at the whirlpool's velocity, and the creature is restrained by the whirlpool until the start of its next turn. If the creature reaches the whirlpool's center, the creature is pulled under the surface and either appears at a special location (see \"Whirlpool Destinations (GoS)\" below) or plunges a number of feet underwater equal to the whirlpool's velocity."
       },
@@ -10225,6 +10339,7 @@
         "name": "Whirlpool Checks",
         "type": "table",
         "value": {
+          "title": "Whirlpool Checks",
           "headers": [
             "Officer",
             "Check"
@@ -10253,6 +10368,7 @@
         "name": "Whirlpool Check Results",
         "type": "table",
         "value": {
+          "title": "Whirlpool Check Results",
           "headers": [
             "Result",
             "Effect"
@@ -10286,6 +10402,7 @@
         "name": "Whirlpool Destinations",
         "type": "table",
         "value": {
+          "title": "Whirlpool Destinations",
           "headers": [
             "d10",
             "Destination"
@@ -10474,6 +10591,7 @@
         "name": "Monster Research",
         "type": "table",
         "value": {
+          "title": "Monster Research",
           "headers": [
             "Type",
             "Suggested Skills"
@@ -10542,6 +10660,7 @@
         "name": "Aberrations",
         "type": "table",
         "value": {
+          "title": "Aberrations",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10570,6 +10689,7 @@
         "name": "Beasts",
         "type": "table",
         "value": {
+          "title": "Beasts",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10598,6 +10718,7 @@
         "name": "Celestials",
         "type": "table",
         "value": {
+          "title": "Celestials",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10626,6 +10747,7 @@
         "name": "Constructs",
         "type": "table",
         "value": {
+          "title": "Constructs",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10654,6 +10776,7 @@
         "name": "Dragons",
         "type": "table",
         "value": {
+          "title": "Dragons",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10682,6 +10805,7 @@
         "name": "Elementals",
         "type": "table",
         "value": {
+          "title": "Elementals",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10710,6 +10834,7 @@
         "name": "Fey",
         "type": "table",
         "value": {
+          "title": "Fey",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10738,6 +10863,7 @@
         "name": "Fiends",
         "type": "table",
         "value": {
+          "title": "Fiends",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10766,6 +10892,7 @@
         "name": "Giants",
         "type": "table",
         "value": {
+          "title": "Giants",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10794,6 +10921,7 @@
         "name": "Humanoids",
         "type": "table",
         "value": {
+          "title": "Humanoids",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10822,6 +10950,7 @@
         "name": "Monstrosities",
         "type": "table",
         "value": {
+          "title": "Monstrosities",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10850,6 +10979,7 @@
         "name": "Oozes",
         "type": "table",
         "value": {
+          "title": "Oozes",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10878,6 +11008,7 @@
         "name": "Plants",
         "type": "table",
         "value": {
+          "title": "Plants",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10906,6 +11037,7 @@
         "name": "Undead",
         "type": "table",
         "value": {
+          "title": "Undead",
           "headers": [
             "d4",
             "Desired Offering"
@@ -10998,6 +11130,7 @@
         "name": "Feywild Time Warp",
         "type": "table",
         "value": {
+          "title": "Feywild Time Warp",
           "headers": [
             "d20",
             "Result"
@@ -11054,6 +11187,7 @@
         "name": "Shadowfell Despair",
         "type": "table",
         "value": {
+          "title": "Shadowfell Despair",
           "headers": [
             "d6",
             "Effect"
@@ -11153,6 +11287,7 @@
         "name": "Abyssal Corruption",
         "type": "table",
         "value": {
+          "title": "Abyssal Corruption",
           "headers": [
             "d10",
             "Result"
@@ -11490,6 +11625,7 @@
         "name": "Proficiency Dice",
         "type": "table",
         "value": {
+          "title": "Proficiency Dice",
           "headers": [
             "Level",
             "Proficiency Bonus",
@@ -11546,6 +11682,7 @@
         "name": "Ship Type",
         "type": "table",
         "value": {
+          "title": "Ship Type",
           "headers": [
             "d100",
             "Ship"
@@ -11587,6 +11724,7 @@
         "name": "Ship Names",
         "type": "table",
         "value": {
+          "title": "Ship Names",
           "headers": [
             "d20",
             "Adjective",
@@ -11710,6 +11848,7 @@
         "name": "Crew Member Name",
         "type": "table",
         "value": {
+          "title": "Crew Member Name",
           "headers": [
             "d20",
             "First Half",
@@ -11828,6 +11967,7 @@
         "name": "Ship Purpose",
         "type": "table",
         "value": {
+          "title": "Ship Purpose",
           "headers": [
             "d100",
             "Purpose"
@@ -11958,6 +12098,7 @@
         "name": "Ship Attitude",
         "type": "table",
         "value": {
+          "title": "Ship Attitude",
           "headers": [
             "d6",
             "Attitude"
@@ -11982,6 +12123,7 @@
         "name": "Friendly Ship",
         "type": "table",
         "value": {
+          "title": "Friendly Ship",
           "headers": [
             "d100",
             "Race"
@@ -12022,6 +12164,7 @@
         "name": "Neutral Ship",
         "type": "table",
         "value": {
+          "title": "Neutral Ship",
           "headers": [
             "d100",
             "Race"
@@ -12062,6 +12205,7 @@
         "name": "Hostile Ship",
         "type": "table",
         "value": {
+          "title": "Hostile Ship",
           "headers": [
             "d100",
             "Race"
@@ -12107,6 +12251,7 @@
         "name": "Ship Disposition",
         "type": "table",
         "value": {
+          "title": "Ship Disposition",
           "headers": [
             "d10",
             "Disposition"
@@ -12158,6 +12303,7 @@
         "name": "Ship Emergency",
         "type": "table",
         "value": {
+          "title": "Ship Emergency",
           "headers": [
             "d4",
             "Emergency"
@@ -12290,6 +12436,7 @@
         "name": "Examples of Faction Ranks",
         "type": "table",
         "value": {
+          "title": "Examples of Faction Ranks",
           "headers": [
             "Renown",
             "Harpers",
@@ -12497,6 +12644,7 @@
         "name": "Scroll Mishap",
         "type": "table",
         "value": {
+          "title": "Scroll Mishap",
           "headers": [
             "d6",
             "Result"
@@ -12609,6 +12757,7 @@
         "name": "Individual Treasure",
         "type": "table",
         "value": {
+          "title": "Individual Treasure",
           "headers": [
             "Level Gained",
             "Lifestyle",
@@ -12682,6 +12831,7 @@
         "name": "Magic Items by Tier",
         "type": "table",
         "value": {
+          "title": "Magic Items by Tier",
           "headers": [
             "Magic Item Table",
             "Available at Tiers",
@@ -12760,6 +12910,7 @@
         "name": "Potions for Sale",
         "type": "table",
         "value": {
+          "title": "Potions for Sale",
           "headers": [
             "Potion of...",
             "Cost"
@@ -12804,6 +12955,7 @@
         "name": "Spell Scrolls for Sale",
         "type": "table",
         "value": {
+          "title": "Spell Scrolls for Sale",
           "headers": [
             "Spell Level",
             "Cost"
@@ -13014,6 +13166,7 @@
         "name": "Starting Encounter Distance",
         "type": "table",
         "value": {
+          "title": "Starting Encounter Distance",
           "headers": [
             "Distance",
             "Notes"
@@ -13136,6 +13289,7 @@
         "name": "Crash Damage",
         "type": "table",
         "value": {
+          "title": "Crash Damage",
           "headers": [
             "Size",
             "Bludgeoning Damage"
@@ -13248,7 +13402,124 @@
       {
         "name": "",
         "type": "text",
-        "value": "**Sidekick Level**: Your sidekick starts as a 1st-level character. As you and your sidekick adventure together, your sidekick gains experience points and reaches new levels the same way a player character does, using the rules in chapter 1.\nWhen a sidekick gains a level, look at the sidekick's table below, and consult the new level's row, which shows the sidekick's new hit point maximum and features.\nThe DM may start a sidekick at a level higher than 1st, using the hit point maximum for its level on the appropriate table below. Also, give the sidekick the features for its current level and any earlier levels on that table.\n[object Object]\n[object Object]\n[object Object]"
+        "value": "**Sidekick Level**: Your sidekick starts as a 1st-level character. As you and your sidekick adventure together, your sidekick gains experience points and reaches new levels the same way a player character does, using the rules in chapter 1.\nWhen a sidekick gains a level, look at the sidekick's table below, and consult the new level's row, which shows the sidekick's new hit point maximum and features.\nThe DM may start a sidekick at a level higher than 1st, using the hit point maximum for its level on the appropriate table below. Also, give the sidekick the features for its current level and any earlier levels on that table."
+      },
+      {
+        "name": "Experts Beyond 1st Level",
+        "type": "table",
+        "value": {
+          "title": "Experts Beyond 1st Level",
+          "headers": [
+            "Level",
+            "Hit Points",
+            "New Features"
+          ],
+          "rows": [
+            [
+              "2nd",
+              "16 (3d8 + 3)",
+              "__Cunning Action__"
+            ],
+            [
+              "3rd",
+              "22 (4d8 + 4)",
+              "__Expertise__"
+            ],
+            [
+              "4th",
+              "27 (5d8 + 5)",
+              "__Ability Score Improvement__"
+            ],
+            [
+              "5th",
+              "33 (6d8 + 6)",
+              "__Proficiency Bonus__"
+            ],
+            [
+              "6th",
+              "38 (7d8 + 7)",
+              "__Extra Attack__"
+            ]
+          ]
+        }
+      },
+      {
+        "name": "Spellcasters Beyond 1st Level",
+        "type": "table",
+        "value": {
+          "title": "Spellcasters Beyond 1st Level",
+          "headers": [
+            "Level",
+            "Hit Points",
+            "New Features"
+          ],
+          "rows": [
+            [
+              "2nd",
+              "13 (3d8)",
+              "__Spellcasting__"
+            ],
+            [
+              "3rd",
+              "18 (4d8)",
+              "__Spellcasting__"
+            ],
+            [
+              "4th",
+              "22 (5d8)",
+              "__Ability Score Improvement__"
+            ],
+            [
+              "5th",
+              "27 (6d8)",
+              "__Proficiency Bonus__ & __Spellcasting__"
+            ],
+            [
+              "6th",
+              "31 (7d8)",
+              "__Potent Cantrips__"
+            ]
+          ]
+        }
+      },
+      {
+        "name": "Warriors Beyond 1st Level",
+        "type": "table",
+        "value": {
+          "title": "Warriors Beyond 1st Level",
+          "headers": [
+            "Level",
+            "Hit Points",
+            "New Features"
+          ],
+          "rows": [
+            [
+              "2nd",
+              "19 (3d8 + 6)",
+              "__Second Wind__"
+            ],
+            [
+              "3rd",
+              "26 (4d8 + 8)",
+              "__Improved Critical__"
+            ],
+            [
+              "4th",
+              "32 (5d8 + 10)",
+              "__Ability Score Improvement__"
+            ],
+            [
+              "5th",
+              "39 (6d8 + 12)",
+              "__Proficiency Bonus__"
+            ],
+            [
+              "6th",
+              "45 (7d8 + 14)",
+              "__Extra Attack__"
+            ]
+          ]
+        }
       }
     ]
   },
@@ -13276,7 +13547,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "**Gaining a Sidekick Class**: When you create a sidekick, you choose the class it will have for the rest of its career: __expert sidekick|TCE|Expert__, __Spellcaster sidekick|TCE|Spellcaster__, or __Warrior sidekick|TCE|Warrior__. If a sidekick class contains a choice, you may make the choice or let the players make it.\n**Starting Level**: The starting level of a sidekick is the same as the average level of the group. For example, if a 1st-level group starts out with a sidekick, that sidekick is also 1st level, but if a 10th-level group invites a sidekick to join them, that sidekick starts at 10th level.\n**Leveling Up a Sidekick**: Whenever a group's average level goes up, the sidekick gains a level. It doesn't matter how much of the group's recent adventures the sidekick experienced; the sidekick levels up because of a combination of the adventures it shared with the group and its own training.\n**Hit Points**: Whenever the sidekick gains a level, it gains one Hit Die, and its hit point maximum increases. To determine the amount of the increase, roll the Hit Die (the type of die appears in the sidekick's stat block), and add its Constitution modifier. It gains a minimum of 1 hit point per level.\nIf the sidekick drops to 0 hit points and isn't killed outright, it falls unconscious and subsequently makes death saving throws, just like a player character.\n**Proficiency Bonus**: The sidekick's proficiency bonus is determined by its level in its class, as shown in the class's table.\nWhenever the sidekick's proficiency bonus increases by 1, add 1 to the to-hit modifier of all the attacks in its stat block, and increase the DCs in its stat block by 1.\n**Ability Score Increases**: Whenever the sidekick gains the Ability Score Improvement feature, adjust anything in its stat block that relies on an ability modifier that you increase. For example, if the sidekick has an attack that uses its Strength modifier, increase the attack's modifiers to hit and damage if the Strength modifier increases.\nIf it's unclear whether a melee attack in the stat block uses Strength or Dexterity, the attack can use either."
+        "value": "**Gaining a Sidekick Class**: When you create a sidekick, you choose the class it will have for the rest of its career: __Expert__, __Spellcaster__, or __Warrior__. If a sidekick class contains a choice, you may make the choice or let the players make it.\n**Starting Level**: The starting level of a sidekick is the same as the average level of the group. For example, if a 1st-level group starts out with a sidekick, that sidekick is also 1st level, but if a 10th-level group invites a sidekick to join them, that sidekick starts at 10th level.\n**Leveling Up a Sidekick**: Whenever a group's average level goes up, the sidekick gains a level. It doesn't matter how much of the group's recent adventures the sidekick experienced; the sidekick levels up because of a combination of the adventures it shared with the group and its own training.\n**Hit Points**: Whenever the sidekick gains a level, it gains one Hit Die, and its hit point maximum increases. To determine the amount of the increase, roll the Hit Die (the type of die appears in the sidekick's stat block), and add its Constitution modifier. It gains a minimum of 1 hit point per level.\nIf the sidekick drops to 0 hit points and isn't killed outright, it falls unconscious and subsequently makes death saving throws, just like a player character.\n**Proficiency Bonus**: The sidekick's proficiency bonus is determined by its level in its class, as shown in the class's table.\nWhenever the sidekick's proficiency bonus increases by 1, add 1 to the to-hit modifier of all the attacks in its stat block, and increase the DCs in its stat block by 1.\n**Ability Score Increases**: Whenever the sidekick gains the Ability Score Improvement feature, adjust anything in its stat block that relies on an ability modifier that you increase. For example, if the sidekick has an attack that uses its Strength modifier, increase the attack's modifiers to hit and damage if the Strength modifier increases.\nIf it's unclear whether a melee attack in the stat block uses Strength or Dexterity, the attack can use either."
       },
       {
         "name": "Creating a Sidekick",
@@ -13392,6 +13663,7 @@
         "name": "Ability Check Proficiency by Class",
         "type": "table",
         "value": {
+          "title": "Ability Check Proficiency by Class",
           "headers": [
             "Class",
             "Ability Check"
@@ -13662,7 +13934,7 @@
       {
         "name": "",
         "type": "text",
-        "value": "The Spell Points by Level table applies to __bard||bards__, __cleric||clerics__, __druid||druids__, __sorcerer||sorcerers__, and __wizard||wizards__. For a __paladin__ or __ranger__, halve the character's level in that class and then consult the table. For a __fighter|phb|fighter (Eldritch Knight)|Eldritch Knight__ or __rogue|phb|rogue (Arcane Trickster)|Arcane Trickster__, divide the character's level in that class by three."
+        "value": "The Spell Points by Level table applies to __bards__, __clerics__, __druids__, __sorcerers__, and __wizards__. For a __paladin__ or __ranger__, halve the character's level in that class and then consult the table. For a __fighter (Eldritch Knight)__ or __rogue (Arcane Trickster)__, divide the character's level in that class by three."
       },
       {
         "name": "",
@@ -13673,6 +13945,7 @@
         "name": "Spell Point Cost",
         "type": "table",
         "value": {
+          "title": "Spell Point Cost",
           "headers": [
             "Spell Level",
             "Point Cost"
@@ -13721,6 +13994,7 @@
         "name": "Spell Points by Level",
         "type": "table",
         "value": {
+          "title": "Spell Points by Level",
           "headers": [
             "Class Level",
             "Spell Points",
@@ -14247,7 +14521,7 @@
         "value": "Make sure your players know how long you plan to use survivors and that they'll be playing their usual characters again soon. Also let them know that survivors are designed to engage with terrifying circumstances, but their triumph over such threats is not assured. Players' decisions will certainly impact the survivors' fates, but if it seems like doom is in store, encourage the players to embrace it and make sure their survivors meet unforgettable ends."
       },
       {
-        "name": "",
+        "name": "What's Old Is New",
         "type": "text",
         "value": "Dwindling resources contribute to terrifying situations. When a group runs out of hit points, spells, food, or other vital reserves, tension and dread increase. High-level characters, though, have such resources in spades. By running an adventure using survivors, you can recapture some of the same tension adventurers experience early in their careers, encouraging players to use their wits and make desperate choices powerful characters can avoid."
       },
@@ -14295,6 +14569,7 @@
         "name": "Survivor Progression",
         "type": "table",
         "value": {
+          "title": "Survivor Progression",
           "headers": [
             "Level",
             "Feature"
@@ -14600,6 +14875,7 @@
         "name": "Alchemist's Supplies",
         "type": "table",
         "value": {
+          "title": "Alchemist's Supplies",
           "headers": [
             "Activity",
             "DC"
@@ -14662,6 +14938,7 @@
         "name": "Brewer's Supplies",
         "type": "table",
         "value": {
+          "title": "Brewer's Supplies",
           "headers": [
             "Activity",
             "DC"
@@ -14711,6 +14988,7 @@
         "name": "Calligrapher's Supplies",
         "type": "table",
         "value": {
+          "title": "Calligrapher's Supplies",
           "headers": [
             "Activity",
             "DC"
@@ -14779,6 +15057,7 @@
         "name": "Carpenter's Tools",
         "type": "table",
         "value": {
+          "title": "Carpenter's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -14837,6 +15116,7 @@
         "name": "Cartographer's Tools",
         "type": "table",
         "value": {
+          "title": "Cartographer's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -14895,6 +15175,7 @@
         "name": "Cobbler's Tools",
         "type": "table",
         "value": {
+          "title": "Cobbler's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -14945,6 +15226,7 @@
         "name": "Cook's Utensils",
         "type": "table",
         "value": {
+          "title": "Cook's Utensils",
           "headers": [
             "Activity",
             "DC"
@@ -15013,6 +15295,7 @@
         "name": "Disguise Kit",
         "type": "table",
         "value": {
+          "title": "Disguise Kit",
           "headers": [
             "Activity",
             "DC"
@@ -15077,6 +15360,7 @@
         "name": "Forgery Kit",
         "type": "table",
         "value": {
+          "title": "Forgery Kit",
           "headers": [
             "Activity",
             "DC"
@@ -15122,6 +15406,7 @@
         "name": "Gaming Set",
         "type": "table",
         "value": {
+          "title": "Gaming Set",
           "headers": [
             "Activity",
             "DC"
@@ -15167,6 +15452,7 @@
         "name": "Glassblower's Tools",
         "type": "table",
         "value": {
+          "title": "Glassblower's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15222,6 +15508,7 @@
         "name": "Herbalism Kit",
         "type": "table",
         "value": {
+          "title": "Herbalism Kit",
           "headers": [
             "Activity",
             "DC"
@@ -15267,6 +15554,7 @@
         "name": "Jeweler's Tools",
         "type": "table",
         "value": {
+          "title": "Jeweler's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15312,6 +15600,7 @@
         "name": "Vehicles",
         "type": "table",
         "value": {
+          "title": "Vehicles",
           "headers": [
             "Activity",
             "DC"
@@ -15361,6 +15650,7 @@
         "name": "Leatherworker's Tools",
         "type": "table",
         "value": {
+          "title": "Leatherworker's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15411,6 +15701,7 @@
         "name": "Mason's Tools",
         "type": "table",
         "value": {
+          "title": "Mason's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15451,6 +15742,7 @@
         "name": "Musical Instrument",
         "type": "table",
         "value": {
+          "title": "Musical Instrument",
           "headers": [
             "Activity",
             "DC"
@@ -15491,6 +15783,7 @@
         "name": "Navigator's Tools",
         "type": "table",
         "value": {
+          "title": "Navigator's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15536,6 +15829,7 @@
         "name": "Painter's Supplies",
         "type": "table",
         "value": {
+          "title": "Painter's Supplies",
           "headers": [
             "Activity",
             "DC"
@@ -15591,6 +15885,7 @@
         "name": "Poisoner's Tools",
         "type": "table",
         "value": {
+          "title": "Poisoner's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15636,6 +15931,7 @@
         "name": "Potter's Tools",
         "type": "table",
         "value": {
+          "title": "Potter's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15685,6 +15981,7 @@
         "name": "Smith's Tools",
         "type": "table",
         "value": {
+          "title": "Smith's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15734,6 +16031,7 @@
         "name": "Thieves' Tools",
         "type": "table",
         "value": {
+          "title": "Thieves' Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15779,6 +16077,7 @@
         "name": "Tinker's Tools",
         "type": "table",
         "value": {
+          "title": "Tinker's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15833,6 +16132,7 @@
         "name": "Weaver's Tools",
         "type": "table",
         "value": {
+          "title": "Weaver's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15887,6 +16187,7 @@
         "name": "Woodcarver's Tools",
         "type": "table",
         "value": {
+          "title": "Woodcarver's Tools",
           "headers": [
             "Activity",
             "DC"
@@ -15927,7 +16228,7 @@
         "value": "If a ship's mode of movement takes damage, it might be slowed. For every decrease of 10 feet in speed, reduce the ship's travel pace by 1 mile per hour and 24 miles per day."
       },
       {
-        "name": "",
+        "name": "Activity While Traveling",
         "type": "text",
         "value": "The activities available to a ship's crew and passengers are a bit different from the options available to a group traveling by land. Refer to \"Activity While Traveling\" in chapter 8 of the Player's Handbook for more information on some of the topics discussed below."
       },
@@ -16015,6 +16316,7 @@
         "name": "Hazard Type",
         "type": "table",
         "value": {
+          "title": "Hazard Type",
           "headers": [
             "d20",
             "Hazard Type"
@@ -16047,6 +16349,7 @@
         "name": "Hazard DC",
         "type": "table",
         "value": {
+          "title": "Hazard DC",
           "headers": [
             "d20",
             "Hazard DC"
@@ -16095,6 +16398,7 @@
         "name": "Crew Conflict DCs",
         "type": "table",
         "value": {
+          "title": "Crew Conflict DCs",
           "headers": [
             "DC",
             "Description"
@@ -16123,6 +16427,7 @@
         "name": "Crew Conflict Checks",
         "type": "table",
         "value": {
+          "title": "Crew Conflict Checks",
           "headers": [
             "Officer",
             "Check"
@@ -16147,6 +16452,7 @@
         "name": "Crew Conflict Check Results",
         "type": "table",
         "value": {
+          "title": "Crew Conflict Check Results",
           "headers": [
             "Result",
             "Effect"
@@ -16190,6 +16496,7 @@
         "name": "Fire DCs",
         "type": "table",
         "value": {
+          "title": "Fire DCs",
           "headers": [
             "DC",
             "Description"
@@ -16218,6 +16525,7 @@
         "name": "Fire Checks",
         "type": "table",
         "value": {
+          "title": "Fire Checks",
           "headers": [
             "Officer",
             "Check"
@@ -16246,6 +16554,7 @@
         "name": "Fire Check Results",
         "type": "table",
         "value": {
+          "title": "Fire Check Results",
           "headers": [
             "Result",
             "Effect"
@@ -16289,6 +16598,7 @@
         "name": "Fog DCs",
         "type": "table",
         "value": {
+          "title": "Fog DCs",
           "headers": [
             "DC",
             "Description"
@@ -16317,6 +16627,7 @@
         "name": "Fog Checks",
         "type": "table",
         "value": {
+          "title": "Fog Checks",
           "headers": [
             "Officer",
             "Check"
@@ -16337,6 +16648,7 @@
         "name": "Fog Check Results",
         "type": "table",
         "value": {
+          "title": "Fog Check Results",
           "headers": [
             "Result",
             "Effect"
@@ -16380,6 +16692,7 @@
         "name": "Infestation DCs",
         "type": "table",
         "value": {
+          "title": "Infestation DCs",
           "headers": [
             "DC",
             "Description"
@@ -16408,6 +16721,7 @@
         "name": "Infestation Checks",
         "type": "table",
         "value": {
+          "title": "Infestation Checks",
           "headers": [
             "Officer",
             "Check"
@@ -16436,6 +16750,7 @@
         "name": "Infestation Check Results",
         "type": "table",
         "value": {
+          "title": "Infestation Check Results",
           "headers": [
             "Result",
             "Effect"
@@ -16479,6 +16794,7 @@
         "name": "Storm DCs",
         "type": "table",
         "value": {
+          "title": "Storm DCs",
           "headers": [
             "DC",
             "Description"
@@ -16507,6 +16823,7 @@
         "name": "Storm Checks",
         "type": "table",
         "value": {
+          "title": "Storm Checks",
           "headers": [
             "Officer",
             "Check"
@@ -16535,6 +16852,7 @@
         "name": "Storm Check Results",
         "type": "table",
         "value": {
+          "title": "Storm Check Results",
           "headers": [
             "Result",
             "Effect"

--- a/generated/spells.json
+++ b/generated/spells.json
@@ -891,6 +891,7 @@
         "name": "Animated Object Statistics",
         "type": "table",
         "value": {
+          "title": "Animated Object Statistics",
           "headers": [
             "Size",
             "HP",
@@ -2010,6 +2011,7 @@
         "name": "Omens",
         "type": "table",
         "value": {
+          "title": "Omens",
           "headers": [
             "Omen",
             "For Results That Will Be..."
@@ -4332,6 +4334,7 @@
         "name": "Chaos Bolt",
         "type": "table",
         "value": {
+          "title": "Chaos Bolt",
           "headers": [
             "d8",
             "Damage Type"
@@ -5811,6 +5814,7 @@
         "name": "Confusion Behavior",
         "type": "table",
         "value": {
+          "title": "Confusion Behavior",
           "headers": [
             "d10",
             "Behavior"
@@ -5885,6 +5889,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d10",
             "Behavior for the Turn"
@@ -7332,6 +7337,7 @@
         "name": "Precipitation",
         "type": "table",
         "value": {
+          "title": "Precipitation",
           "headers": [
             "Stage",
             "Condition"
@@ -7364,6 +7370,7 @@
         "name": "Temperature",
         "type": "table",
         "value": {
+          "title": "Temperature",
           "headers": [
             "Stage",
             "Condition"
@@ -7400,6 +7407,7 @@
         "name": "Wind",
         "type": "table",
         "value": {
+          "title": "Wind",
           "headers": [
             "Stage",
             "Condition"
@@ -7474,6 +7482,7 @@
         "name": "Precipitation",
         "type": "table",
         "value": {
+          "title": "Precipitation",
           "headers": [
             "Stage",
             "Condition"
@@ -7506,6 +7515,7 @@
         "name": "Temperature",
         "type": "table",
         "value": {
+          "title": "Temperature",
           "headers": [
             "Stage",
             "Condition"
@@ -7542,6 +7552,7 @@
         "name": "Wind",
         "type": "table",
         "value": {
+          "title": "Wind",
           "headers": [
             "Stage",
             "Condition"
@@ -8225,6 +8236,7 @@
         "name": "Creation",
         "type": "table",
         "value": {
+          "title": "Creation",
           "headers": [
             "Material",
             "Duration"
@@ -8299,6 +8311,7 @@
         "name": "Materials",
         "type": "table",
         "value": {
+          "title": "Materials",
           "headers": [
             "Material",
             "Duration"
@@ -10691,6 +10704,7 @@
         "name": "Divine Word Effects",
         "type": "table",
         "value": {
+          "title": "Divine Word Effects",
           "headers": [
             "Hit Points",
             "Effect"
@@ -25520,6 +25534,7 @@
         "name": "Mischievous Surge",
         "type": "table",
         "value": {
+          "title": "Mischievous Surge",
           "headers": [
             "d4",
             "Effect"
@@ -25854,6 +25869,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d8",
             "Octarine Spray Effect"
@@ -27720,6 +27736,7 @@
         "name": "Prismatic Rays",
         "type": "table",
         "value": {
+          "title": "Prismatic Rays",
           "headers": [
             "1d8",
             "Ray"
@@ -27894,6 +27911,7 @@
         "name": "Prismatic Layers",
         "type": "table",
         "value": {
+          "title": "Prismatic Layers",
           "headers": [
             "Order",
             "Effects"
@@ -29279,6 +29297,7 @@
         "name": "Reality Break Effects",
         "type": "table",
         "value": {
+          "title": "Reality Break Effects",
           "headers": [
             "d10",
             "Effect"
@@ -29405,6 +29424,7 @@
         "name": "Reincarnate Races",
         "type": "table",
         "value": {
+          "title": "Reincarnate Races",
           "headers": [
             "d100",
             "Race"
@@ -29502,6 +29522,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "1d10",
             "Species"
@@ -30478,6 +30499,7 @@
         "name": "Knowledge of Target",
         "type": "table",
         "value": {
+          "title": "Knowledge of Target",
           "headers": [
             "Knowledge",
             "Save Modifier"
@@ -30502,6 +30524,7 @@
         "name": "Connection to Target",
         "type": "table",
         "value": {
+          "title": "Connection to Target",
           "headers": [
             "Connection",
             "Save Modifier"
@@ -30581,6 +30604,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "Your Knowledge of the Target Is...",
             "Save Modifier"
@@ -30605,6 +30629,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "You Have the Target's...",
             "Save Modifier"
@@ -34744,6 +34769,7 @@
         "name": "",
         "type": "table",
         "value": {
+          "title": "",
           "headers": [
             "d6",
             "Demons Summoned"
@@ -35936,6 +35962,7 @@
         "name": "Teleportation",
         "type": "table",
         "value": {
+          "title": "Teleportation",
           "headers": [
             "Familiarity",
             "Mishap",
@@ -36062,6 +36089,7 @@
         "name": "Teleportation Outcome",
         "type": "table",
         "value": {
+          "title": "Teleportation Outcome",
           "headers": [
             "Familiarity",
             "Mishap",

--- a/src/classes.ts
+++ b/src/classes.ts
@@ -415,6 +415,7 @@ class CharacterClass {
                         name: title,
                         type: DescriptionType.table,
                         value: {
+                            title,
                             headers,
                             rows: [spellRow],
                         },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import { BulletPoint, getNumberSign, joinStringsWithOr } from './util';
+import { BulletPoint, getNumberSign, joinStringsWithAnd, joinStringsWithOr } from './util';
 import {
     get5eToolsUrl,
     getBackgroundsUrl,
@@ -228,11 +228,11 @@ export function cleanDNDText(text: string, noFormat: boolean = false): string {
         // as such, ignore checking for remaining '{' and '}' for now
         return text;
     }
-    if (text.includes('{')) {
-        throw `Unmatched '{' character found in '${text}'`;
-    }
-    if (text.includes('}')) {
-        throw `Unmatched '}' character found in '${text}'`;
+
+    const disallowedSymbols = ['{', '}', '[', ']', '|'];
+    const foundSymbols = disallowedSymbols.filter((s) => text.includes(s)).map((s) => `'${s}'`);
+    if (foundSymbols.length > 0) {
+        throw `Unmatched symbol${foundSymbols.length > 1 ? 's' : ''} ${joinStringsWithAnd(foundSymbols)} found in '${text}'`;
     }
 
     return text;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -23,6 +23,7 @@ export interface Description {
 }
 
 export interface Table {
+    title: string;
     headers: string[];
     rows: string[][];
 }
@@ -75,6 +76,7 @@ export function cleanDNDText(text: string, noFormat: boolean = false): string {
     text = text.replaceAll(/\{@book ([^\}]*?)\|([^\}]*?)\}/g, '$1');
     text = text.replaceAll(/\{@card ([^\}]*?)\|([^\}]*?)\}/g, '$1');
     text = text.replaceAll(/\{@chance ([^\}]*?)\|\|\|([^\}]*?)\|([^\}]*?)\}/g, '$1 percent');
+    text = text.replaceAll(/\{@chance ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '$2');
     text = text.replaceAll(/\{@chance ([^\}]*?)\}/g, '$1 percent');
     text = text.replaceAll(/\{@classFeature ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '$1');
     text = text.replaceAll(/\{@color ([^\}]*?)\|([^\}]*?)\}/g, '$1');
@@ -86,6 +88,7 @@ export function cleanDNDText(text: string, noFormat: boolean = false): string {
     text = text.replaceAll(/\{@deck ([^\}]*?)\|([^\}]*?)\}/g, '$1');
     text = text.replaceAll(/\{@deck ([^\}]*?)\}/g, '$1');
     text = text.replaceAll(/\{@deity ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '$1');
+    text = text.replaceAll(/\{@dice #\$prompt([^\}]*?)\|([^\}]*?)\}/g, '$2'); // See rule Carrying Capacity
     text = text.replaceAll(/\{@dice ([^\}]*?)\|([^\}]*?)\}/g, '$1 ($2)');
     text = text.replaceAll(/\{@dice ([^\}]*?)\}/g, '$1');
     text = text.replaceAll(/\{@filter ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '$1');
@@ -99,6 +102,7 @@ export function cleanDNDText(text: string, noFormat: boolean = false): string {
     text = text.replaceAll(/\{@item ([^\}]*?)\|([^\}]*?)\}/g, '$1');
     text = text.replaceAll(/\{@item ([^\}]*?)\}/g, '$1');
     text = text.replaceAll(/\{@itemProperty ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '$3');
+    text = text.replaceAll(/\{@language ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '$3');
     text = text.replaceAll(/\{@language ([^\}]*?)\}/g, '$1');
     text = text.replaceAll(/\{@link ([^\}]*?)\|([^\}]*?)\}/g, '[$1]($2)');
     text = text.replaceAll(/\{@loader ([^\}]*?)\|([^\}]*?)\}/g, '$1');
@@ -126,10 +130,13 @@ export function cleanDNDText(text: string, noFormat: boolean = false): string {
 
     if (noFormat) {
         text = text.replaceAll(/\{@h\}/g, 'Hit: ');
+        text = text.replaceAll(/\{@class ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, `$3`);
+        text = text.replaceAll(/\{@class ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, `$3`);
         text = text.replaceAll(/\{@class ([^\}]*?)\}/g, `$1`);
         text = text.replaceAll(/\{@creature ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '$3');
         text = text.replaceAll(/\{@creature ([^\}]*?)(\|[^\}]*?)?\}/g, '$1');
         text = text.replaceAll(/\{@disease ([^\}]*?)\}/g, '$1');
+        text = text.replaceAll(/\{@damage ([^\}]*?)\|([^\}]*?)\}/g, '$2');
         text = text.replaceAll(/\{@damage ([^\}]*?)\}/g, '$1');
         text = text.replaceAll(/\{@scaledamage ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '$3');
         text = text.replaceAll(/\{@scaledice ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '$3');
@@ -158,10 +165,13 @@ export function cleanDNDText(text: string, noFormat: boolean = false): string {
         text = text.replaceAll(/\{@vehupgrade ([^\}]*?)\|([^\}]*?)\}/g, `$1`);
     } else {
         text = text.replaceAll(/\{@h\}/g, '*Hit:* ');
+        text = text.replaceAll(/\{@class ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, `__$3__`);
+        text = text.replaceAll(/\{@class ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, `__$3__`);
         text = text.replaceAll(/\{@class ([^\}]*?)\}/g, `__$1__`);
         text = text.replaceAll(/\{@creature ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '__$3__');
         text = text.replaceAll(/\{@creature ([^\}]*?)(\|[^\}]*?)?\}/g, '__$1__');
         text = text.replaceAll(/\{@disease ([^\}]*?)\}/g, '__$1__');
+        text = text.replaceAll(/\{@damage ([^\}]*?)\|([^\}]*?)\}/g, '**$2**');
         text = text.replaceAll(/\{@damage ([^\}]*?)\}/g, '**$1**');
         text = text.replaceAll(/\{@scaledamage ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '**$3**');
         text = text.replaceAll(/\{@scaledice ([^\}]*?)\|([^\}]*?)\|([^\}]*?)\}/g, '**$3**');
@@ -229,7 +239,7 @@ export function cleanDNDText(text: string, noFormat: boolean = false): string {
         return text;
     }
 
-    const disallowedSymbols = ['{', '}', '[', ']', '|'];
+    const disallowedSymbols = ['{', '}', '|', '[object Object]'];
     const foundSymbols = disallowedSymbols.filter((s) => text.includes(s)).map((s) => `'${s}'`);
     if (foundSymbols.length > 0) {
         throw `Unmatched symbol${foundSymbols.length > 1 ? 's' : ''} ${joinStringsWithAnd(foundSymbols)} found in '${text}'`;
@@ -406,62 +416,78 @@ function parseDescriptionBlockFromBlocks(descriptions: any[]): string {
     return blocks.join('\n\n');
 }
 
-function parseDescriptionBlock(description: string | any): string | Table {
+function splitDescriptionTypes(values: (string | Table)[]): { strings: string[]; tables: Table[] } {
+    const strings = [];
+    const tables = [];
+    for (const value of values) {
+        if (typeof value === 'string') strings.push(value);
+        else tables.push(value);
+    }
+    return { strings, tables };
+}
+
+function parseDescriptionBlock(description: string | any): (string | Table)[] {
     if (typeof description == 'string') {
-        return cleanDNDText(description);
+        return [cleanDNDText(description)];
     }
 
     switch (description.type) {
         case 'quote': {
             const quote = parseDescriptionBlockFromBlocks(description.entries);
-            if (description.by) return `*${quote}* - ${description.by}`;
-            return `*${quote}*`;
+            if (description.by) return [`*${quote}* - ${description.by}`];
+            return [`*${quote}*`];
         }
         case 'list': {
-            const points: string[] = [];
-            for (const item of description.items)
-                points.push(`${BulletPoint} ${parseDescriptionBlock(item)}`);
-            return points.join('\n');
+            const entries = description.items.flatMap(parseDescriptionBlock);
+            const { strings, tables } = splitDescriptionTypes(entries);
+            const points = strings.map((str) => `${BulletPoint} ${str}`).join('\n');
+            return [points, ...tables];
         }
         case 'inset':
         case 'insetReadaloud': {
-            let text = `*${parseDescriptionBlockFromBlocks(description.entries)}*`;
-            return cleanDNDText(text);
+            const entries = description.entries.flatMap(parseDescriptionBlock);
+            const { strings, tables } = splitDescriptionTypes(entries);
+            const entry = strings.map((str) => `*${str}*`).join('\n');
+            return [entry, ...tables];
         }
         case 'item': {
             const entries: (string | Table)[] = [];
             if (description.entries) {
-                entries.push(...description.entries.map(parseDescriptionBlock));
+                entries.push(...description.entries.flatMap(parseDescriptionBlock));
             } else if (description.entry) {
-                entries.push(parseDescriptionBlock(description.entry));
+                entries.push(...parseDescriptionBlock(description.entry));
             } else {
                 throw "Could not find entry in description block with type 'item'";
             }
-            const entry = entries.join('\n');
-            return cleanDNDText(`**${description.name}**: ${entry}`);
+
+            const { strings, tables } = splitDescriptionTypes(entries);
+            const entry = strings.join('\n');
+            return [cleanDNDText(`**${description.name}**: ${entry}`), ...tables];
         }
         case 'inline': {
-            const entries = description.entries.map(parseDescriptionBlock);
+            const entries = description.entries.flatMap(parseDescriptionBlock);
             let entry = entries.join('');
-            if (description.name) return cleanDNDText(`**${description.name}**: ${entry}`);
-            return cleanDNDText(entry);
+            if (description.name) return [cleanDNDText(`**${description.name}**: ${entry}`)];
+            return [cleanDNDText(entry)];
         }
         case 'section':
         case 'entries': {
-            const entries = description.entries.map(parseDescriptionBlock);
-            let entry = entries.join('\n');
-            if (description.name) return cleanDNDText(`**${description.name}**: ${entry}`);
-            return cleanDNDText(entry);
+            const entries = description.entries.flatMap(parseDescriptionBlock);
+            const { strings, tables } = splitDescriptionTypes(entries);
+            let entry = strings.join('\n');
+            if (description.name)
+                return [cleanDNDText(`**${description.name}**: ${entry}`), ...tables];
+            return [cleanDNDText(entry), ...tables];
         }
         case 'entry': {
-            return cleanDNDText(description.entry);
+            return [cleanDNDText(description.entry)];
         }
         case 'table': {
             const table = parseDescriptionFromTable(description);
-            return table.value;
+            return [table.value];
         }
         case 'image': {
-            return ''; // Images will not be handled within descriptions
+            return []; // Images will not be handled within descriptions
         }
         case 'abilityAttackMod':
         case 'abilityDc': {
@@ -469,7 +495,7 @@ function parseDescriptionBlock(description: string | any): string | Table {
 
             const abilityScores = description.attributes.map(parseAbilityScore);
             const text = `${BulletPoint} *${description.name} ${titleDesc}:* ${joinStringsWithOr(abilityScores)} modifier + Proficiency Bonus`;
-            return text;
+            return [text];
         }
         case 'refClassFeature': {
             // classFeature is a string like "Sorcery Points|Sorcerer||2"
@@ -479,8 +505,8 @@ function parseDescriptionBlock(description: string | any): string | Table {
                 if (parts.length >= 4) {
                     const name = parts[0];
                     const value = parts[3];
-                    if (value && name) return `${BulletPoint} **${value}** ${name}`;
-                    if (name) return name;
+                    if (value && name) return [`${BulletPoint} **${value}** ${name}`];
+                    if (name) return [name];
                 }
             }
 
@@ -491,21 +517,21 @@ function parseDescriptionBlock(description: string | any): string | Table {
             if (typeof classFeature === 'string') {
                 const [name, , , , , value] = classFeature.split('|');
                 if (value && name) {
-                    return `${BulletPoint} **${value}** ${name}`;
+                    return [`${BulletPoint} **${value}** ${name}`];
                 }
-                return name || classFeature;
+                return [name || classFeature];
             }
             throw `Unsupported refSubclassFeature ${classFeature}`;
         }
         case 'refOptionalfeature': {
-            let optionalFeature = description.optionalfeature;
+            let optionalFeature: string = description.optionalfeature;
 
             if (optionalFeature.includes('|')) {
                 const [name, source] = optionalFeature.split('|');
                 optionalFeature = `${name} (${source})`;
             }
 
-            return optionalFeature;
+            return [optionalFeature];
         }
         case 'options': {
             const entries: string[] = [];
@@ -515,7 +541,7 @@ function parseDescriptionBlock(description: string | any): string | Table {
             }
 
             const title = count ? `Choose **${count}:**\n` : '';
-            return `${title}${entries.join('\n ')}`;
+            return [`${title}${entries.join('\n ')}`];
         }
         case 'statblock': {
             const tag = description.tag;
@@ -535,13 +561,13 @@ function parseDescriptionBlock(description: string | any): string | Table {
             }
 
             if (!link) throw `Unsupported statblock ${tag}`;
-            return `[See ${name}'s stats here](${link})`;
+            return [`[See ${name}'s stats here](${link})`];
         }
         case 'refFeat': {
             const feat = description.feat;
             const [name, source] = feat.split('|');
             const link = getFeatsUrl(name, source);
-            return `${BulletPoint} [${name}](${link})`;
+            return [`${BulletPoint} [${name}](${link})`];
         }
         case 'link': {
             const text = description.text;
@@ -560,7 +586,7 @@ function parseDescriptionBlock(description: string | any): string | Table {
             }
 
             if (!url) throw `Unsupported link ${description}`;
-            return `[${text}](${url})`;
+            return [`[${text}](${url})`];
         }
         default: {
             throw `Unsupported description type: '${description.type}'`;
@@ -606,7 +632,7 @@ function parseDescriptionFromTable(description: any): Description {
     const title: string = description.caption || '';
     const headers: string[] = description.colLabels.map(cleanDNDText);
     const rows: string[][] = description.rows.map((row: string[]) => row.map(parseTableValue));
-    const table: Table = { headers: headers, rows: rows };
+    const table: Table = { title, headers, rows };
 
     return { name: title, type: DescriptionType.table, value: table };
 }
@@ -626,17 +652,26 @@ export function parseDescriptions(name: string, descriptions: any[]): Descriptio
             } else if (desc.type == 'table') {
                 subdescriptions.push(parseDescriptionFromTable(desc));
             } else {
-                blocks.push(parseDescriptionBlock(desc));
+                blocks.push(...parseDescriptionBlock(desc));
             }
         }
     }
 
+    function toDescription(name: string, value: string | Table): Description {
+        name = typeof value === 'string' ? name : name || value.title;
+        return {
+            name,
+            type: typeof value === 'string' ? DescriptionType.text : DescriptionType.table,
+            value,
+        };
+    }
+
     const results: Description[] = [];
     if (blocks.length > 0) {
-        results.push({ name: name, type: DescriptionType.text, value: blocks[0] });
+        results.push(toDescription(name, blocks[0]));
     }
     for (let i = 1; i < blocks.length; i++) {
-        results.push({ name: '', type: DescriptionType.text, value: blocks[i] });
+        results.push(toDescription('', blocks[i]));
     }
     results.push(...subdescriptions);
 


### PR DESCRIPTION
The [object Object] entries were caused by nested tables. To solve this, these are now handled by returning a list of values, from which the tables are separated. For this, several new changes were made, which I believe are correct and not detrimental.

- Table now has a title, which is useful for nested tables
- Several double newlines are now removed, namely from inset. These are now replaced by a single newline
- Harsher checking for errors in cleanDNDText. Now `|` and `[object Object]` are also disallowed. To account for this, several new rules were added.

Closes #47 