### PR TITLE
Add uniform read method

### DIFF
--- a/src/dnd/spells.ts
+++ b/src/dnd/spells.ts
@@ -95,15 +95,15 @@ function getSpell(spell: any, fluffs: any[], sources: any): Spell {
 }
 
 interface GetSpellsArgs {
-    path: string;
-    fluffPath?: string;
-    sourcesPath?: string;
+    paths: string[];
+    fluffPaths?: string[];
+    sourcesPaths?: string[];
 }
 
 export function getSpells(paths: GetSpellsArgs): Spell[] {
-    const spells = read(paths.path).spell;
-    const fluffs = paths.fluffPath ? read(paths.fluffPath).spellFluff : [];
-    const sources = paths.sourcesPath ? read(paths.sourcesPath) : {};
+    const spells = read(paths.paths).spell;
+    const fluffs = read(paths.fluffPaths).spellFluff || [];
+    const sources = read(paths.sourcesPaths);
 
     const result = [];
     for (const spell of spells) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,9 +34,9 @@ function main(): void {
     stopwatch.log('Items variant retrieved');
 
     const spells = getSpells({
-        path: './5etools-src/data/spells/index.json',
-        fluffPath: './5etools-src/data/spells/fluff-index.json',
-        sourcesPath: './5etools-src/data/spells/sources.json',
+        paths: ['./5etools-src/data/spells/index.json'],
+        fluffPaths: ['./5etools-src/data/spells/fluff-index.json'],
+        sourcesPaths: ['./5etools-src/data/spells/sources.json'],
     });
     stopwatch.log('Spells retrieved');
 

--- a/src/read.ts
+++ b/src/read.ts
@@ -68,23 +68,41 @@ function readDirectoryFiles(directory: string) {
  * - A pure directory path. In this case, all files in the directory are considered and aggregated,
  *   such as is the case for partnered content.
  *
- * @param filepath The file or directory path
+ * In case undefined is given, an empty object is returned
+ *
+ * @param filepaths The file or directory path. Multiple can be given, in which case each is handled
+ *                  separately, and are then aggregated.
  * @returns An object that aggregates all data from the files
  */
-export function read(filepath: string): any {
-    // Check if file is an index file
-    if (filepath.endsWith('index.json')) {
-        return readIndexFile(filepath);
+export function read(filepaths: string | string[] | undefined): any {
+    if (!filepaths) {
+        return {};
     }
 
-    if (filepath.endsWith('.json')) {
-        return readJsonFile(filepath);
+    const data: any[] = [];
+
+    if (!Array.isArray(filepaths)) {
+        filepaths = [filepaths];
     }
 
-    const stats = fs.lstatSync(filepath);
-    if (stats.isDirectory()) {
-        return readDirectoryFiles(filepath);
+    for (const filepath of filepaths) {
+        const stats = fs.lstatSync(filepath);
+        // Check if file is an index file
+        if (filepath.endsWith('index.json')) {
+            data.push(readIndexFile(filepath));
+        } else if (filepath.endsWith('.json')) {
+            data.push(readJsonFile(filepath));
+        } else if (stats.isDirectory()) {
+            data.push(readDirectoryFiles(filepath));
+        } else {
+            throw new Error(`Unsupported filepath type: ${filepath}`);
+        }
     }
 
-    throw new Error(`Unsupported filepath type: ${filepath}`);
+    if (data.length === 1) {
+        // Specific case to handle single objects that do not handle combineContents well
+        return data[0];
+    }
+
+    return data.reduce(combineContents, {});
 }


### PR DESCRIPTION
Adds a function named `read` that can be used to read the different ways 5e.tools stores data. This function returns a single object containing all the data from the read file(s):
- If the path is a single .json file, return that file's contents
- If the path is an index.json file, return the data from all the files in that index.json file
- If the path is a directory, return the data from all files in that directory

This should allow us to move away from the global database system we have now, and would allow our code to be more separated